### PR TITLE
fix: upgrade wireup to 2.9.0 and fix event bus transactional consistency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ pytz==2024.2
 structlog==25.2.0
 sqlalchemy==2.0.40
 uvicorn==0.32.1
-wireup==2.7.0
+wireup==2.9.0
 aiokafka==0.12.0

--- a/src/catalog/product/domain/entities.py
+++ b/src/catalog/product/domain/entities.py
@@ -24,7 +24,7 @@ class Product(Entity):
     sale_price: Decimal | None = None
     unit_of_measure_id: int | None = None
     is_active: bool = True
-    tax_rate: Decimal = Decimal("12.00")
+    tax_rate: Decimal = Decimal("15.00")
     is_service: bool = False
     min_stock: int = 0
     max_stock: int | None = None

--- a/src/catalog/product/infra/mappers.py
+++ b/src/catalog/product/infra/mappers.py
@@ -5,12 +5,12 @@ from src.catalog.product.infra.models import CategoryModel, ProductModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class CategoryMapper(Mapper[Category, CategoryModel]):
     __entity__ = Category
 
 
-@injectable
+@injectable(lifetime="singleton")
 class ProductMapper(Mapper[Product, ProductModel]):
     __entity__ = Product
     __exclude_fields__ = frozenset({"created_at"})

--- a/src/catalog/product/infra/validators.py
+++ b/src/catalog/product/infra/validators.py
@@ -23,7 +23,7 @@ class ProductRequest(BaseModel):
     unit_of_measure_id: int | None = Field(None, ge=1)
     purchase_price: DecimalNumber | None = Field(None, ge=0)
     sale_price: DecimalNumber | None = Field(None, ge=0)
-    tax_rate: DecimalNumber = Field(Decimal("12.00"), ge=0, le=100)
+    tax_rate: DecimalNumber = Field(Decimal("15.00"), ge=0, le=100)
     is_active: bool = True
     is_service: bool = False
     min_stock: int = Field(0, ge=0)

--- a/src/catalog/uom/infra/mappers.py
+++ b/src/catalog/uom/infra/mappers.py
@@ -5,6 +5,6 @@ from src.catalog.uom.infra.models import UnitOfMeasureModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class UnitOfMeasureMapper(Mapper[UnitOfMeasure, UnitOfMeasureModel]):
     __entity__ = UnitOfMeasure

--- a/src/customers/infra/mappers.py
+++ b/src/customers/infra/mappers.py
@@ -5,12 +5,12 @@ from src.customers.infra.models import CustomerContactModel, CustomerModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class CustomerMapper(Mapper[Customer, CustomerModel]):
     __entity__ = Customer
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class CustomerContactMapper(Mapper[CustomerContact, CustomerContactModel]):
     __entity__ = CustomerContact

--- a/src/inventory/adjustment/infra/mappers.py
+++ b/src/inventory/adjustment/infra/mappers.py
@@ -6,12 +6,12 @@ from src.shared.infra.mappers import Mapper
 from .models import AdjustmentItemModel, InventoryAdjustmentModel
 
 
-@injectable
+@injectable(lifetime="singleton")
 class InventoryAdjustmentMapper(Mapper[InventoryAdjustment, InventoryAdjustmentModel]):
     __entity__ = InventoryAdjustment
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class AdjustmentItemMapper(Mapper[AdjustmentItem, AdjustmentItemModel]):
     __entity__ = AdjustmentItem

--- a/src/inventory/infra/event_handlers.py
+++ b/src/inventory/infra/event_handlers.py
@@ -3,6 +3,8 @@ Event handlers que reaccionan a eventos de otros módulos.
 Estos handlers permiten el desacoplamiento entre módulos vía eventos.
 """
 
+from typing import Any
+
 import structlog
 
 from src.inventory.movement.app.commands import (
@@ -12,12 +14,13 @@ from src.inventory.movement.app.commands import (
 from src.inventory.movement.domain.constants import MovementType
 from src.sales.domain.events import SaleCancelled, SaleConfirmed
 from src.shared.infra.events.decorators import event_handler
+from src.shared.infra.events.scope import create_sync_scope
 
 logger = structlog.get_logger(__name__)
 
 
 @event_handler(SaleConfirmed)
-def handle_sale_confirmed(event: SaleConfirmed) -> None:
+def handle_sale_confirmed(event: SaleConfirmed, session: Any = None) -> None:
     """
     Cuando se confirma una venta, crear movimientos OUT de inventario.
     Este handler desacopla el módulo de sales del módulo de inventory.
@@ -32,9 +35,7 @@ def handle_sale_confirmed(event: SaleConfirmed) -> None:
 
     logger.info("handling_sale_confirmed", sale_id=event.sale_id)
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             for item in event.items:
                 handler = scope.get(CreateMovementCommandHandler)
@@ -64,7 +65,7 @@ def handle_sale_confirmed(event: SaleConfirmed) -> None:
 
 
 @event_handler(SaleCancelled)
-def handle_sale_cancelled(event: SaleCancelled) -> None:
+def handle_sale_cancelled(event: SaleCancelled, session: Any = None) -> None:
     """
     Cuando se cancela una venta, revertir movimientos si la venta estaba confirmada.
     Solo crea movimientos IN si was_confirmed=True.
@@ -91,9 +92,7 @@ def handle_sale_cancelled(event: SaleCancelled) -> None:
         )
         return
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             for item in event.items:
                 handler = scope.get(CreateMovementCommandHandler)

--- a/src/inventory/location/infra/mappers.py
+++ b/src/inventory/location/infra/mappers.py
@@ -5,6 +5,6 @@ from src.inventory.location.infra.models import LocationModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class LocationMapper(Mapper[Location, LocationModel]):
     __entity__ = Location

--- a/src/inventory/lot/infra/event_handlers.py
+++ b/src/inventory/lot/infra/event_handlers.py
@@ -3,16 +3,21 @@ Event handlers for Lot that react to purchasing domain events.
 Creates or updates lots when purchase orders are received.
 """
 
+from typing import Any
+
 import structlog
 
 from src.purchasing.domain.events import PurchaseOrderReceived
 from src.shared.infra.events.decorators import event_handler
+from src.shared.infra.events.scope import create_sync_scope
 
 logger = structlog.get_logger(__name__)
 
 
 @event_handler(PurchaseOrderReceived)
-def handle_purchase_order_received_lots(event: PurchaseOrderReceived) -> None:
+def handle_purchase_order_received_lots(
+    event: PurchaseOrderReceived, session: Any = None
+) -> None:
     """
     When goods are received for a purchase order, create or update lots.
     Only processes items that include a lot_number.
@@ -27,9 +32,7 @@ def handle_purchase_order_received_lots(event: PurchaseOrderReceived) -> None:
         items_with_lots=len(items_with_lots),
     )
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             from dataclasses import replace
 

--- a/src/inventory/lot/infra/mappers.py
+++ b/src/inventory/lot/infra/mappers.py
@@ -5,12 +5,12 @@ from src.inventory.lot.infra.models import LotModel, MovementLotItemModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class LotMapper(Mapper[Lot, LotModel]):
     __entity__ = Lot
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class MovementLotItemMapper(Mapper[MovementLotItem, MovementLotItemModel]):
     __entity__ = MovementLotItem

--- a/src/inventory/movement/app/commands/movement.py
+++ b/src/inventory/movement/app/commands/movement.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+from sqlalchemy.orm import Session
 from wireup import injectable
 
 from src.inventory.movement.domain.constants import MovementType
@@ -31,9 +32,15 @@ class CreateMovementCommandHandler(CommandHandler[CreateMovementCommand, dict]):
     Publica el evento MovementCreated que será consumido por el Stock event handler.
     """
 
-    def __init__(self, repo: Repository[Movement], event_publisher: EventPublisher):
+    def __init__(
+        self,
+        repo: Repository[Movement],
+        event_publisher: EventPublisher,
+        session: Session,
+    ):
         self.repo = repo
         self.event_publisher = event_publisher
+        self.session = session
 
     def _handle(self, command: CreateMovementCommand) -> dict:
         movement_type = MovementType(command.type)
@@ -61,7 +68,8 @@ class CreateMovementCommandHandler(CommandHandler[CreateMovementCommand, dict]):
                 location_id=movement.location_id,
                 reason=movement.reason,
                 date=movement.date,
-            )
+            ),
+            session=self.session,
         )
 
         return movement.dict()

--- a/src/inventory/movement/infra/mappers.py
+++ b/src/inventory/movement/infra/mappers.py
@@ -6,7 +6,7 @@ from src.shared.infra.mappers import Mapper
 from .models import MovementModel
 
 
-@injectable
+@injectable(lifetime="singleton")
 class MovementMapper(Mapper[Movement, MovementModel]):
     __entity__ = Movement
     __exclude_fields__ = frozenset({"created_at"})

--- a/src/inventory/serial/infra/event_handlers.py
+++ b/src/inventory/serial/infra/event_handlers.py
@@ -3,16 +3,21 @@ Event handlers for Serial Numbers that react to purchasing domain events.
 Creates serial numbers when purchase orders are received.
 """
 
+from typing import Any
+
 import structlog
 
 from src.purchasing.domain.events import PurchaseOrderReceived
 from src.shared.infra.events.decorators import event_handler
+from src.shared.infra.events.scope import create_sync_scope
 
 logger = structlog.get_logger(__name__)
 
 
 @event_handler(PurchaseOrderReceived)
-def handle_purchase_order_received_serials(event: PurchaseOrderReceived) -> None:
+def handle_purchase_order_received_serials(
+    event: PurchaseOrderReceived, session: Any = None
+) -> None:
     """
     When goods are received for a purchase order, create serial numbers.
     Only processes items that include serial_numbers list.
@@ -27,9 +32,7 @@ def handle_purchase_order_received_serials(event: PurchaseOrderReceived) -> None
         items_with_serials=len(items_with_serials),
     )
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             from src.inventory.lot.domain.entities import Lot
             from src.inventory.serial.domain.entities import SerialNumber, SerialStatus

--- a/src/inventory/serial/infra/mappers.py
+++ b/src/inventory/serial/infra/mappers.py
@@ -5,7 +5,7 @@ from src.inventory.serial.infra.models import SerialNumberModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SerialNumberMapper(Mapper[SerialNumber, SerialNumberModel]):
     __entity__ = SerialNumber
     __exclude_fields__ = frozenset({"created_at"})

--- a/src/inventory/stock/infra/event_handlers.py
+++ b/src/inventory/stock/infra/event_handlers.py
@@ -3,6 +3,8 @@ Event handlers para Stock que reaccionan a eventos de otros módulos.
 Este handler desacopla Movement de Stock mediante eventos.
 """
 
+from typing import Any
+
 import structlog
 
 from src.inventory.movement.domain.events import MovementCreated
@@ -11,12 +13,13 @@ from src.inventory.stock.domain.events import StockCreated, StockUpdated
 from src.shared.app.repositories import Repository
 from src.shared.infra.events.decorators import event_handler
 from src.shared.infra.events.event_bus import EventBus
+from src.shared.infra.events.scope import create_sync_scope
 
 logger = structlog.get_logger(__name__)
 
 
 @event_handler(MovementCreated)
-def handle_movement_created(event: MovementCreated) -> None:
+def handle_movement_created(event: MovementCreated, session: Any = None) -> None:
     """
     Cuando se crea un movimiento, actualizar o crear el stock correspondiente.
     El stock se maneja por (product_id, location_id). Si location_id es None,
@@ -30,9 +33,7 @@ def handle_movement_created(event: MovementCreated) -> None:
         location_id=event.location_id,
     )
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             stock_repo = scope.get(Repository[Stock])
 
@@ -63,7 +64,8 @@ def handle_movement_created(event: MovementCreated) -> None:
                         product_id=stock.product_id,
                         quantity=stock.quantity,
                         location_id=stock.location_id,
-                    )
+                    ),
+                    session=session,
                 )
                 logger.info(
                     "stock_created",
@@ -92,7 +94,8 @@ def handle_movement_created(event: MovementCreated) -> None:
                         old_quantity=old_quantity,
                         new_quantity=stock.quantity,
                         location_id=stock.location_id,
-                    )
+                    ),
+                    session=session,
                 )
                 logger.info(
                     "stock_updated",

--- a/src/inventory/stock/infra/mappers.py
+++ b/src/inventory/stock/infra/mappers.py
@@ -5,6 +5,6 @@ from src.inventory.stock.infra.models import StockModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class StockMapper(Mapper[Stock, StockModel]):
     __entity__ = Stock

--- a/src/inventory/transfer/infra/mappers.py
+++ b/src/inventory/transfer/infra/mappers.py
@@ -6,12 +6,12 @@ from src.shared.infra.mappers import Mapper
 from .models import StockTransferItemModel, StockTransferModel
 
 
-@injectable
+@injectable(lifetime="singleton")
 class StockTransferMapper(Mapper[StockTransfer, StockTransferModel]):
     __entity__ = StockTransfer
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class StockTransferItemMapper(Mapper[StockTransferItem, StockTransferItemModel]):
     __entity__ = StockTransferItem

--- a/src/inventory/warehouse/infra/mappers.py
+++ b/src/inventory/warehouse/infra/mappers.py
@@ -5,7 +5,7 @@ from src.inventory.warehouse.infra.models import WarehouseModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class WarehouseMapper(Mapper[Warehouse, WarehouseModel]):
     __entity__ = Warehouse
     __exclude_fields__ = frozenset({"created_at"})

--- a/src/pos/cash/infra/mappers.py
+++ b/src/pos/cash/infra/mappers.py
@@ -5,6 +5,6 @@ from src.pos.cash.infra.models import CashMovementModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class CashMovementMapper(Mapper[CashMovement, CashMovementModel]):
     __entity__ = CashMovement

--- a/src/pos/refund/infra/mappers.py
+++ b/src/pos/refund/infra/mappers.py
@@ -5,16 +5,16 @@ from src.pos.refund.infra.models import RefundItemModel, RefundModel, RefundPaym
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class RefundMapper(Mapper[Refund, RefundModel]):
     __entity__ = Refund
 
 
-@injectable
+@injectable(lifetime="singleton")
 class RefundItemMapper(Mapper[RefundItem, RefundItemModel]):
     __entity__ = RefundItem
 
 
-@injectable
+@injectable(lifetime="singleton")
 class RefundPaymentMapper(Mapper[RefundPayment, RefundPaymentModel]):
     __entity__ = RefundPayment

--- a/src/pos/shift/infra/mappers.py
+++ b/src/pos/shift/infra/mappers.py
@@ -5,6 +5,6 @@ from src.pos.shift.infra.models import ShiftModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class ShiftMapper(Mapper[Shift, ShiftModel]):
     __entity__ = Shift

--- a/src/purchasing/app/commands/purchase_receipt.py
+++ b/src/purchasing/app/commands/purchase_receipt.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, replace
 from datetime import datetime
 
+from sqlalchemy.orm import Session
 from wireup import injectable
 
 from src.purchasing.domain.entities import (
@@ -49,12 +50,14 @@ class CreatePurchaseReceiptCommandHandler(
         receipt_repo: Repository[PurchaseReceipt],
         receipt_item_repo: Repository[PurchaseReceiptItem],
         event_publisher: EventPublisher,
+        session: Session,
     ):
         self.po_repo = po_repo
         self.item_repo = item_repo
         self.receipt_repo = receipt_repo
         self.receipt_item_repo = receipt_item_repo
         self.event_publisher = event_publisher
+        self.session = session
 
     def _handle(self, command: CreatePurchaseReceiptCommand) -> dict:
         purchase_order = self.po_repo.get_by_id(command.purchase_order_id)
@@ -151,7 +154,8 @@ class CreatePurchaseReceiptCommandHandler(
                 order_number=updated_po.order_number,
                 is_complete=all_received,
                 items=receipt_items_data,
-            )
+            ),
+            session=self.session,
         )
 
         return receipt.dict()

--- a/src/purchasing/infra/event_handlers.py
+++ b/src/purchasing/infra/event_handlers.py
@@ -2,6 +2,8 @@
 Event handlers that react to purchasing domain events.
 """
 
+from typing import Any
+
 import structlog
 
 from src.inventory.movement.app.commands.movement import (
@@ -11,12 +13,15 @@ from src.inventory.movement.app.commands.movement import (
 from src.inventory.movement.domain.constants import MovementType
 from src.purchasing.domain.events import PurchaseOrderReceived
 from src.shared.infra.events.decorators import event_handler
+from src.shared.infra.events.scope import create_sync_scope
 
 logger = structlog.get_logger(__name__)
 
 
 @event_handler(PurchaseOrderReceived)
-def handle_purchase_order_received(event: PurchaseOrderReceived) -> None:
+def handle_purchase_order_received(
+    event: PurchaseOrderReceived, session: Any = None
+) -> None:
     """
     When goods are received for a purchase order, create IN inventory movements.
     Each receipt item becomes an individual IN movement.
@@ -29,9 +34,7 @@ def handle_purchase_order_received(event: PurchaseOrderReceived) -> None:
         item_count=len(event.items),
     )
 
-    from src import wireup_container
-
-    with wireup_container.enter_scope() as scope:
+    with create_sync_scope(session) as scope:
         try:
             for item in event.items:
                 handler = scope.get(CreateMovementCommandHandler)

--- a/src/purchasing/infra/mappers.py
+++ b/src/purchasing/infra/mappers.py
@@ -15,23 +15,23 @@ from src.purchasing.infra.models import (
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class PurchaseOrderMapper(Mapper[PurchaseOrder, PurchaseOrderModel]):
     __entity__ = PurchaseOrder
     __exclude_fields__ = frozenset({"created_at", "updated_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class PurchaseOrderItemMapper(Mapper[PurchaseOrderItem, PurchaseOrderItemModel]):
     __entity__ = PurchaseOrderItem
 
 
-@injectable
+@injectable(lifetime="singleton")
 class PurchaseReceiptMapper(Mapper[PurchaseReceipt, PurchaseReceiptModel]):
     __entity__ = PurchaseReceipt
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class PurchaseReceiptItemMapper(Mapper[PurchaseReceiptItem, PurchaseReceiptItemModel]):
     __entity__ = PurchaseReceiptItem

--- a/src/sales/infra/mappers.py
+++ b/src/sales/infra/mappers.py
@@ -5,18 +5,18 @@ from src.sales.infra.models import PaymentModel, SaleItemModel, SaleModel
 from src.shared.infra.mappers import Mapper
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SaleMapper(Mapper[Sale, SaleModel]):
     __entity__ = Sale
     __exclude_fields__ = frozenset({"created_at", "updated_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SaleItemMapper(Mapper[SaleItem, SaleItemModel]):
     __entity__ = SaleItem
 
 
-@injectable
+@injectable(lifetime="singleton")
 class PaymentMapper(Mapper[Payment, PaymentModel]):
     __entity__ = Payment
     __exclude_fields__ = frozenset({"created_at"})

--- a/src/shared/app/events.py
+++ b/src/shared/app/events.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 from src.shared.domain.events import DomainEvent
 
 
 class EventPublisher(ABC):
     @abstractmethod
-    def publish(self, event: DomainEvent) -> None:
+    def publish(self, event: DomainEvent, session: Any = None) -> None:
         raise NotImplementedError

--- a/src/shared/infra/events/decorators.py
+++ b/src/shared/infra/events/decorators.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Any
 
 from src.shared.domain.events import DomainEvent
 from src.shared.infra.events.event_bus import EventBus
@@ -6,7 +7,12 @@ from src.shared.infra.events.event_bus import EventBus
 
 def event_handler(event_type: type[DomainEvent]) -> Callable:
     def decorator(func: Callable) -> Callable:
-        EventBus.subscribe(event_type, func)
+        def wrapper(event: DomainEvent, session: Any = None) -> None:
+            func(event, session=session)
+
+        wrapper.__name__ = func.__name__
+        wrapper.__qualname__ = func.__qualname__
+        EventBus.subscribe(event_type, wrapper)
         return func
 
     return decorator

--- a/src/shared/infra/events/event_bus.py
+++ b/src/shared/infra/events/event_bus.py
@@ -1,5 +1,7 @@
+import inspect
 from collections import defaultdict
 from collections.abc import Callable
+from typing import Any
 
 import structlog
 from opentelemetry import trace
@@ -16,13 +18,19 @@ tracer = trace.get_tracer(__name__)
 
 class EventBus:
     _subscribers: dict[type[DomainEvent], list[Callable]] = defaultdict(list)
+    _accepts_session: dict[int, bool] = {}
 
     @classmethod
     def subscribe(cls, event_type: type[DomainEvent], handler: Callable) -> None:
         cls._subscribers[event_type].append(handler)
+        try:
+            sig = inspect.signature(handler)
+            cls._accepts_session[id(handler)] = "session" in sig.parameters
+        except (ValueError, TypeError):
+            cls._accepts_session[id(handler)] = False
 
     @classmethod
-    def publish(cls, event: DomainEvent) -> None:
+    def publish(cls, event: DomainEvent, session: Any = None) -> None:
         event_type = type(event)
         event_type_name = event_type.__name__
         handlers = cls._subscribers.get(event_type, [])
@@ -51,7 +59,10 @@ class EventBus:
                     },
                 ) as span:
                     try:
-                        handler(event)
+                        if cls._accepts_session.get(id(handler), False):
+                            handler(event, session=session)
+                        else:
+                            handler(event)
                         span.set_status(trace.StatusCode.OK)
                     except Exception as e:
                         logger.error(
@@ -69,7 +80,9 @@ class EventBus:
                         )
                         span.set_status(trace.StatusCode.ERROR, str(e))
                         span.record_exception(e)
+                        raise
 
     @classmethod
     def clear(cls) -> None:
         cls._subscribers.clear()
+        cls._accepts_session.clear()

--- a/src/shared/infra/events/event_bus_publisher.py
+++ b/src/shared/infra/events/event_bus_publisher.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from wireup import injectable
 
 from src.shared.app.events import EventPublisher
@@ -7,5 +9,5 @@ from src.shared.infra.events.event_bus import EventBus
 
 @injectable(lifetime="singleton", as_type=EventPublisher)
 class EventBusPublisher(EventPublisher):
-    def publish(self, event: DomainEvent) -> None:
-        EventBus.publish(event)
+    def publish(self, event: DomainEvent, session: Any = None) -> None:
+        EventBus.publish(event, session=session)

--- a/src/shared/infra/events/scope.py
+++ b/src/shared/infra/events/scope.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from sqlalchemy.orm import Session
+from wireup.ioc.container.async_container import async_container_force_sync_scope
+from wireup.ioc.container.sync_container import ScopedSyncContainer
+
+
+def create_sync_scope(session: Any = None) -> ScopedSyncContainer:
+    """Create a synchronous scope from the async wireup container.
+
+    If a session is provided, it will be reused in the new scope,
+    ensuring transactional consistency across event handler chains.
+    If no session is provided, a new scope with a fresh session is created.
+    """
+    from src import wireup_container
+
+    provided = {Session: session} if session is not None else None
+    return async_container_force_sync_scope(wireup_container, provided)

--- a/src/shared/infra/kafka/event_handlers.py
+++ b/src/shared/infra/kafka/event_handlers.py
@@ -1,7 +1,10 @@
+from typing import Any
+
 import structlog
 
 from src.sales.domain.events import SaleConfirmed
 from src.shared.infra.events.decorators import event_handler
+from src.shared.infra.events.scope import create_sync_scope
 from src.shared.infra.kafka.producer import KafkaEventProducer
 
 logger = structlog.get_logger(__name__)
@@ -23,8 +26,7 @@ def _get_producer() -> KafkaEventProducer | None:
     return _producer
 
 
-def _build_enriched_payload(event: SaleConfirmed) -> dict:
-    from src import wireup_container
+def _build_enriched_payload(event: SaleConfirmed, session: Any = None) -> dict:
     from src.catalog.product.domain.entities import Product
     from src.customers.domain.entities import Customer
     from src.shared.app.repositories import Repository
@@ -32,27 +34,26 @@ def _build_enriched_payload(event: SaleConfirmed) -> dict:
     customer_data = None
     enriched_items = []
 
-    scope = wireup_container.enter_scope()
+    with create_sync_scope(session) as scope:
+        if event.customer_id:
+            customer_repo = scope.get(Repository[Customer])
+            customer = customer_repo.get_by_id(event.customer_id)
+            if customer:
+                customer_data = {
+                    "id": customer.id,
+                    "name": customer.name,
+                    "tax_id": customer.tax_id,
+                    "tax_type": customer.tax_type.name,
+                    "email": customer.email,
+                    "phone": customer.phone,
+                    "address": customer.address,
+                }
 
-    if event.customer_id:
-        customer_repo = scope._synchronous_get(Repository[Customer])
-        customer = customer_repo.get_by_id(event.customer_id)
-        if customer:
-            customer_data = {
-                "id": customer.id,
-                "name": customer.name,
-                "tax_id": customer.tax_id,
-                "tax_type": customer.tax_type.name,
-                "email": customer.email,
-                "phone": customer.phone,
-                "address": customer.address,
-            }
-
-    product_repo = scope._synchronous_get(Repository[Product])
-    product_ids = {item["product_id"] for item in event.items}
-    products = {
-        p.id: p for p in (product_repo.get_by_id(pid) for pid in product_ids) if p
-    }
+        product_repo = scope.get(Repository[Product])
+        product_ids = {item["product_id"] for item in event.items}
+        products = {
+            p.id: p for p in (product_repo.get_by_id(pid) for pid in product_ids) if p
+        }
 
     for item in event.items:
         product = products.get(item["product_id"])
@@ -89,13 +90,13 @@ def _build_enriched_payload(event: SaleConfirmed) -> dict:
 
 
 @event_handler(SaleConfirmed)
-def publish_sale_confirmed_to_kafka(event: SaleConfirmed) -> None:
+def publish_sale_confirmed_to_kafka(event: SaleConfirmed, session: Any = None) -> None:
     producer = _get_producer()
     if producer is None:
         return
 
     try:
-        enriched = _build_enriched_payload(event)
+        enriched = _build_enriched_payload(event, session=session)
         producer.send_raw("sales.confirmed", enriched, event_type="SaleConfirmed")
     except Exception:
         logger.error(

--- a/src/suppliers/infra/mappers.py
+++ b/src/suppliers/infra/mappers.py
@@ -9,17 +9,17 @@ from src.suppliers.infra.models import (
 )
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SupplierMapper(Mapper[Supplier, SupplierModel]):
     __entity__ = Supplier
     __exclude_fields__ = frozenset({"created_at"})
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SupplierContactMapper(Mapper[SupplierContact, SupplierContactModel]):
     __entity__ = SupplierContact
 
 
-@injectable
+@injectable(lifetime="singleton")
 class SupplierProductMapper(Mapper[SupplierProduct, SupplierProductModel]):
     __entity__ = SupplierProduct

--- a/tests/integration/inventory/test_movement_stock_integration.py
+++ b/tests/integration/inventory/test_movement_stock_integration.py
@@ -40,8 +40,8 @@ def clear_event_bus():
     EventBus.clear()
 
 
-@patch("src.wireup_container")
-def test_create_movement_triggers_stock_update_via_event(mock_stock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_create_movement_triggers_stock_update_via_event(mock_stock_scope):
     """
     Integration test: Creating a movement publishes MovementCreated,
     which triggers handle_movement_created, which updates stock.
@@ -59,7 +59,7 @@ def test_create_movement_triggers_stock_update_via_event(mock_stock_container):
     # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_stock_repo
-    mock_stock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_stock_scope.return_value.__enter__.return_value = mock_scope
 
     # Movement to create
     created_movement = Movement(
@@ -80,7 +80,9 @@ def test_create_movement_triggers_stock_update_via_event(mock_stock_container):
     EventBus.subscribe(StockCreated, stock_listener)
 
     # Create command handler
-    handler = CreateMovementCommandHandler(mock_movement_repo, EventBusPublisher())
+    handler = CreateMovementCommandHandler(
+        mock_movement_repo, EventBusPublisher(), Mock()
+    )
     command = CreateMovementCommand(
         product_id=10,
         quantity=10,
@@ -108,13 +110,15 @@ def test_create_movement_triggers_stock_update_via_event(mock_stock_container):
     assert stock_events[0].product_id == 10
 
 
-@patch("src.wireup_container")
-def test_sale_confirmed_creates_movement_and_updates_stock(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+@patch("src.inventory.infra.event_handlers.create_sync_scope")
+def test_sale_confirmed_creates_movement_and_updates_stock(
+    mock_inv_scope, mock_stock_scope
+):
     """
     Integration test: SaleConfirmed → CreateMovement → MovementCreated → Stock updated
     """
     # Arrange
-    # Handlers are already registered by the fixture
     mock_movement_repo = Mock()
     mock_stock_repo = Mock()
 
@@ -137,9 +141,6 @@ def test_sale_confirmed_creates_movement_and_updates_stock(mock_container):
 
     # Mock command handler that publishes MovementCreated event like the real one
     def mock_handle(command):
-        # Simulate what the real handler does:
-        # 1. Create movement (mocked via repo)
-        # 2. Publish MovementCreated event
         EventBus.publish(
             MovementCreated(
                 aggregate_id=created_movement.id,
@@ -154,20 +155,20 @@ def test_sale_confirmed_creates_movement_and_updates_stock(mock_container):
     mock_command_handler = Mock()
     mock_command_handler.handle.side_effect = mock_handle
 
-    # Mock the scope context manager
-    # The scope.get() needs to return different things based on what's resolved:
-    # - CreateMovementCommandHandler for sales event handlers
-    # - Repository[Stock] for stock event handlers
-    def scope_get_side_effect(type_class):
+    # Mock the inventory scope (for SaleConfirmed handler)
+    def inv_scope_get(type_class):
         if type_class == CreateMovementCommandHandler:
             return mock_command_handler
-        elif type_class.__name__ == "Repository":  # Repository[Stock]
-            return mock_stock_repo
         raise ValueError(f"Unexpected resolve: {type_class}")
 
-    mock_scope = Mock()
-    mock_scope.get.side_effect = scope_get_side_effect
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_inv_scope_obj = Mock()
+    mock_inv_scope_obj.get.side_effect = inv_scope_get
+    mock_inv_scope.return_value.__enter__.return_value = mock_inv_scope_obj
+
+    # Mock the stock scope (for MovementCreated handler)
+    mock_stock_scope_obj = Mock()
+    mock_stock_scope_obj.get.return_value = mock_stock_repo
+    mock_stock_scope.return_value.__enter__.return_value = mock_stock_scope_obj
 
     # Track events
     stock_events = []
@@ -207,13 +208,13 @@ def test_sale_confirmed_creates_movement_and_updates_stock(mock_container):
     assert stock_events[0].new_quantity == 95
 
 
-@patch("src.wireup_container")
-def test_sale_cancelled_reverts_stock_via_event(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+@patch("src.inventory.infra.event_handlers.create_sync_scope")
+def test_sale_cancelled_reverts_stock_via_event(mock_inv_scope, mock_stock_scope):
     """
     Integration test: SaleCancelled (was_confirmed=True) → CreateMovement IN → Stock restored
     """
     # Arrange
-    # Handlers are already registered by the fixture
     mock_movement_repo = Mock()
     mock_stock_repo = Mock()
 
@@ -229,17 +230,13 @@ def test_sale_cancelled_reverts_stock_via_event(mock_container):
     reversal_movement = Movement(
         id=2,
         product_id=10,
-        quantity=5,  # Positive for IN
+        quantity=5,
         type=MovementType.IN,
         reason="Sale #123 cancelled - reversal",
     )
     mock_movement_repo.create.return_value = reversal_movement
 
-    # Mock command handler that publishes MovementCreated event like the real one
     def mock_handle(command):
-        # Simulate what the real handler does:
-        # 1. Create movement (mocked via repo)
-        # 2. Publish MovementCreated event
         EventBus.publish(
             MovementCreated(
                 aggregate_id=reversal_movement.id,
@@ -254,20 +251,20 @@ def test_sale_cancelled_reverts_stock_via_event(mock_container):
     mock_command_handler = Mock()
     mock_command_handler.handle.side_effect = mock_handle
 
-    # Mock the scope context manager
-    # The scope.get() needs to return different things based on what's resolved:
-    # - CreateMovementCommandHandler for sales event handlers
-    # - Repository[Stock] for stock event handlers
-    def scope_get_side_effect(type_class):
+    # Mock the inventory scope
+    def inv_scope_get(type_class):
         if type_class == CreateMovementCommandHandler:
             return mock_command_handler
-        elif type_class.__name__ == "Repository":  # Repository[Stock]
-            return mock_stock_repo
         raise ValueError(f"Unexpected resolve: {type_class}")
 
-    mock_scope = Mock()
-    mock_scope.get.side_effect = scope_get_side_effect
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_inv_scope_obj = Mock()
+    mock_inv_scope_obj.get.side_effect = inv_scope_get
+    mock_inv_scope.return_value.__enter__.return_value = mock_inv_scope_obj
+
+    # Mock the stock scope
+    mock_stock_scope_obj = Mock()
+    mock_stock_scope_obj.get.return_value = mock_stock_repo
+    mock_stock_scope.return_value.__enter__.return_value = mock_stock_scope_obj
 
     # Track events
     stock_events = []
@@ -284,7 +281,7 @@ def test_sale_cancelled_reverts_stock_via_event(mock_container):
         customer_id=1,
         items=[{"product_id": 10, "quantity": 5}],
         reason="Customer request",
-        was_confirmed=True,  # Stock needs to be restored
+        was_confirmed=True,
     )
 
     # Act
@@ -295,7 +292,7 @@ def test_sale_cancelled_reverts_stock_via_event(mock_container):
     mock_command_handler.handle.assert_called_once()
     call_args = mock_command_handler.handle.call_args[0][0]
     assert call_args.product_id == 10
-    assert call_args.quantity == 5  # Positive for reversal
+    assert call_args.quantity == 5
     assert call_args.type == MovementType.IN.value
 
     # 2. Stock was restored
@@ -308,15 +305,13 @@ def test_sale_cancelled_reverts_stock_via_event(mock_container):
     assert stock_events[0].new_quantity == 100
 
 
-@patch("src.wireup_container")
-def test_sale_cancelled_draft_no_stock_change(mock_inventory_container):
+@patch("src.inventory.infra.event_handlers.create_sync_scope")
+def test_sale_cancelled_draft_no_stock_change(mock_inv_scope):
     """
     Integration test: SaleCancelled (was_confirmed=False) → No movement created
     """
     # Arrange
-    # Handlers are already registered by the fixture
     mock_command_handler = Mock()
-    mock_inventory_container.get.return_value = mock_command_handler
 
     # Sale cancelled event (was NOT confirmed)
     cancel_event = SaleCancelled(
@@ -325,7 +320,7 @@ def test_sale_cancelled_draft_no_stock_change(mock_inventory_container):
         customer_id=1,
         items=[{"product_id": 10, "quantity": 5}],
         reason="Customer request",
-        was_confirmed=False,  # No stock to restore
+        was_confirmed=False,
     )
 
     # Act
@@ -336,8 +331,8 @@ def test_sale_cancelled_draft_no_stock_change(mock_inventory_container):
     mock_command_handler.handle.assert_not_called()
 
 
-@patch("src.wireup_container")
-def test_multiple_movements_accumulate_stock(mock_stock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_multiple_movements_accumulate_stock(mock_stock_scope):
     """
     Integration test: Multiple movements update stock cumulatively
     """
@@ -367,9 +362,11 @@ def test_multiple_movements_accumulate_stock(mock_stock_container):
     # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_stock_repo
-    mock_stock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_stock_scope.return_value.__enter__.return_value = mock_scope
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, EventBusPublisher())
+    handler = CreateMovementCommandHandler(
+        mock_movement_repo, EventBusPublisher(), Mock()
+    )
 
     # Movement 1: +10
     mock_movement_repo.create.return_value = Movement(

--- a/tests/unit/inventory/lot/test_event_handlers.py
+++ b/tests/unit/inventory/lot/test_event_handlers.py
@@ -53,11 +53,9 @@ def _make_scope(lot_repo, movement_lot_item_repo, movement_repo):
 # ---------------------------------------------------------------------------
 
 
-@patch("src.wireup_container")
-def test_skips_items_without_lot_number(mock_container):
+@patch("src.inventory.lot.infra.event_handlers.create_sync_scope")
+def test_skips_items_without_lot_number(mock_create_scope):
     """Items without lot_number should not trigger lot creation."""
-    from src.inventory.lot.infra import event_handlers  # noqa: F401
-
     event = _make_event(
         items=[
             {
@@ -76,14 +74,12 @@ def test_skips_items_without_lot_number(mock_container):
 
     handle_purchase_order_received_lots(event)
 
-    mock_container.enter_scope.assert_not_called()
+    mock_create_scope.assert_not_called()
 
 
-@patch("src.wireup_container")
-def test_creates_new_lot_when_not_exists(mock_container):
+@patch("src.inventory.lot.infra.event_handlers.create_sync_scope")
+def test_creates_new_lot_when_not_exists(mock_create_scope):
     """Creates a new lot when lot_number is provided and doesn't exist."""
-    from src.inventory.lot.infra import event_handlers  # noqa: F401
-
     lot = _make_lot()
     event = _make_event(
         items=[
@@ -106,7 +102,7 @@ def test_creates_new_lot_when_not_exists(mock_container):
     movement_repo.filter_by.return_value = []
 
     mock_scope = _make_scope(lot_repo, movement_lot_item_repo, movement_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.lot.infra.event_handlers import (
         handle_purchase_order_received_lots,
@@ -123,11 +119,9 @@ def test_creates_new_lot_when_not_exists(mock_container):
     assert created.current_quantity == 10
 
 
-@patch("src.wireup_container")
-def test_updates_existing_lot_quantity(mock_container):
+@patch("src.inventory.lot.infra.event_handlers.create_sync_scope")
+def test_updates_existing_lot_quantity(mock_create_scope):
     """Updates current_quantity when lot already exists."""
-    from src.inventory.lot.infra import event_handlers  # noqa: F401
-
     existing_lot = _make_lot(current_quantity=50)
     updated_lot = _make_lot(current_quantity=60)
     event = _make_event(
@@ -151,7 +145,7 @@ def test_updates_existing_lot_quantity(mock_container):
     movement_repo.filter_by.return_value = []
 
     mock_scope = _make_scope(lot_repo, movement_lot_item_repo, movement_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.lot.infra.event_handlers import (
         handle_purchase_order_received_lots,
@@ -165,10 +159,9 @@ def test_updates_existing_lot_quantity(mock_container):
     assert updated.current_quantity == 60  # 50 + 10
 
 
-@patch("src.wireup_container")
-def test_creates_movement_lot_item_when_movement_exists(mock_container):
+@patch("src.inventory.lot.infra.event_handlers.create_sync_scope")
+def test_creates_movement_lot_item_when_movement_exists(mock_create_scope):
     """Creates MovementLotItem linking movement to lot."""
-    from src.inventory.lot.infra import event_handlers  # noqa: F401
     from src.inventory.movement.domain.constants import MovementType
     from src.inventory.movement.domain.entities import Movement
 
@@ -206,7 +199,7 @@ def test_creates_movement_lot_item_when_movement_exists(mock_container):
     movement_repo.filter_by.return_value = [movement]
 
     mock_scope = _make_scope(lot_repo, movement_lot_item_repo, movement_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.lot.infra.event_handlers import (
         handle_purchase_order_received_lots,
@@ -227,10 +220,9 @@ def test_creates_movement_lot_item_when_movement_exists(mock_container):
     assert created.quantity == 10
 
 
-@patch("src.wireup_container")
-def test_does_not_reuse_movement_for_duplicate_product_items(mock_container):
+@patch("src.inventory.lot.infra.event_handlers.create_sync_scope")
+def test_does_not_reuse_movement_for_duplicate_product_items(mock_create_scope):
     """Each item gets its own movement even with same product_id."""
-    from src.inventory.lot.infra import event_handlers  # noqa: F401
     from src.inventory.movement.domain.constants import MovementType
     from src.inventory.movement.domain.entities import Movement
 
@@ -284,7 +276,7 @@ def test_does_not_reuse_movement_for_duplicate_product_items(mock_container):
     movement_repo.filter_by.return_value = [movement1, movement2]
 
     mock_scope = _make_scope(lot_repo, movement_lot_item_repo, movement_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.lot.infra.event_handlers import (
         handle_purchase_order_received_lots,

--- a/tests/unit/inventory/movement/test_commands.py
+++ b/tests/unit/inventory/movement/test_commands.py
@@ -45,7 +45,7 @@ def test_create_movement_in_command_handler_success(
         reason="Purchase order #123",
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     result = handler.handle(command)
 
@@ -75,7 +75,7 @@ def test_create_movement_out_command_handler_success(
         reason="Sale #456",
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     result = handler.handle(command)
 
@@ -105,7 +105,7 @@ def test_create_movement_publishes_movement_created_event(
         date=datetime.now(),
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
     handler.handle(command)
 
     event_publisher.publish.assert_called_once()
@@ -127,7 +127,7 @@ def test_create_movement_in_with_negative_quantity_raises(
         type=MovementType.IN.value,
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     with pytest.raises(InvalidMovementTypeError) as exc_info:
         handler.handle(command)
@@ -147,7 +147,7 @@ def test_create_movement_out_with_positive_quantity_raises(
         type=MovementType.OUT.value,
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     with pytest.raises(InvalidMovementTypeError) as exc_info:
         handler.handle(command)
@@ -165,7 +165,7 @@ def test_create_movement_zero_quantity_raises(mock_movement_repo, event_publishe
         type=MovementType.IN.value,
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     with pytest.raises(InvalidMovementTypeError) as exc_info:
         handler.handle(command)
@@ -193,7 +193,7 @@ def test_create_movement_with_date(mock_movement_repo, event_publisher):
         date=specific_date,
     )
 
-    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher)
+    handler = CreateMovementCommandHandler(mock_movement_repo, event_publisher, Mock())
 
     result = handler.handle(command)
 

--- a/tests/unit/inventory/serial/test_event_handlers.py
+++ b/tests/unit/inventory/serial/test_event_handlers.py
@@ -40,8 +40,8 @@ def _make_scope(serial_repo, lot_repo):
 # ---------------------------------------------------------------------------
 
 
-@patch("src.wireup_container")
-def test_skips_items_without_serial_numbers(mock_container):
+@patch("src.inventory.serial.infra.event_handlers.create_sync_scope")
+def test_skips_items_without_serial_numbers(mock_create_scope):
     """Items without serial_numbers should not trigger serial creation."""
     from src.inventory.serial.infra import event_handlers  # noqa: F401
 
@@ -63,11 +63,11 @@ def test_skips_items_without_serial_numbers(mock_container):
 
     handle_purchase_order_received_serials(event)
 
-    mock_container.enter_scope.assert_not_called()
+    mock_create_scope.assert_not_called()
 
 
-@patch("src.wireup_container")
-def test_creates_serial_numbers_when_provided(mock_container):
+@patch("src.inventory.serial.infra.event_handlers.create_sync_scope")
+def test_creates_serial_numbers_when_provided(mock_create_scope):
     """Creates serial numbers for items with serial_numbers list."""
     from src.inventory.serial.infra import event_handlers  # noqa: F401
 
@@ -95,7 +95,7 @@ def test_creates_serial_numbers_when_provided(mock_container):
     lot_repo.first.return_value = None
 
     mock_scope = _make_scope(serial_repo, lot_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.serial.infra.event_handlers import (
         handle_purchase_order_received_serials,
@@ -112,8 +112,8 @@ def test_creates_serial_numbers_when_provided(mock_container):
     assert created.lot_id is None
 
 
-@patch("src.wireup_container")
-def test_associates_lot_id_when_lot_number_provided(mock_container):
+@patch("src.inventory.serial.infra.event_handlers.create_sync_scope")
+def test_associates_lot_id_when_lot_number_provided(mock_create_scope):
     """Associates lot_id when lot_number is present in the item."""
     from src.inventory.serial.infra import event_handlers  # noqa: F401
 
@@ -153,7 +153,7 @@ def test_associates_lot_id_when_lot_number_provided(mock_container):
     lot_repo.first.return_value = lot
 
     mock_scope = _make_scope(serial_repo, lot_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.serial.infra.event_handlers import (
         handle_purchase_order_received_serials,
@@ -165,8 +165,8 @@ def test_associates_lot_id_when_lot_number_provided(mock_container):
     assert created.lot_id == 3
 
 
-@patch("src.wireup_container")
-def test_skips_duplicate_serial_numbers(mock_container):
+@patch("src.inventory.serial.infra.event_handlers.create_sync_scope")
+def test_skips_duplicate_serial_numbers(mock_create_scope):
     """Does not create a serial that already exists."""
     from src.inventory.serial.infra import event_handlers  # noqa: F401
 
@@ -193,7 +193,7 @@ def test_skips_duplicate_serial_numbers(mock_container):
     lot_repo.first.return_value = None
 
     mock_scope = _make_scope(serial_repo, lot_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.serial.infra.event_handlers import (
         handle_purchase_order_received_serials,
@@ -204,8 +204,8 @@ def test_skips_duplicate_serial_numbers(mock_container):
     serial_repo.create.assert_not_called()
 
 
-@patch("src.wireup_container")
-def test_logs_error_when_serial_exists_for_different_product(mock_container):
+@patch("src.inventory.serial.infra.event_handlers.create_sync_scope")
+def test_logs_error_when_serial_exists_for_different_product(mock_create_scope):
     """Logs error when serial already exists for a different product."""
     from src.inventory.serial.infra import event_handlers  # noqa: F401
 
@@ -232,7 +232,7 @@ def test_logs_error_when_serial_exists_for_different_product(mock_container):
     lot_repo.first.return_value = None
 
     mock_scope = _make_scope(serial_repo, lot_repo)
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     from src.inventory.serial.infra.event_handlers import (
         handle_purchase_order_received_serials,

--- a/tests/unit/inventory/stock/test_event_handlers.py
+++ b/tests/unit/inventory/stock/test_event_handlers.py
@@ -21,20 +21,18 @@ def clear_event_bus():
     EventBus.clear()
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_creates_new_stock(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_creates_new_stock(mock_create_scope):
     """Test that MovementCreated event creates new stock when none exists"""
-    # Arrange
     mock_repo = Mock()
-    mock_repo.first.return_value = None  # No existing stock
+    mock_repo.first.return_value = None
 
     new_stock = Stock(id=1, product_id=10, quantity=5)
     mock_repo.create.return_value = new_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     events_received = []
 
@@ -51,19 +49,15 @@ def test_handle_movement_created_creates_new_stock(mock_container):
         reason="Initial stock",
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     mock_repo.first.assert_called_once_with(product_id=10, location_id=None)
     mock_repo.create.assert_called_once()
 
-    # Verify the created stock
     created_stock = mock_repo.create.call_args[0][0]
     assert created_stock.product_id == 10
     assert created_stock.quantity == 5
 
-    # Verify StockCreated event was published
     assert len(events_received) == 1
     stock_event = events_received[0]
     assert isinstance(stock_event, StockCreated)
@@ -72,10 +66,9 @@ def test_handle_movement_created_creates_new_stock(mock_container):
     assert stock_event.quantity == 5
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_updates_existing_stock(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_updates_existing_stock(mock_create_scope):
     """Test that MovementCreated event updates existing stock"""
-    # Arrange
     existing_stock = Stock(id=1, product_id=10, quantity=100)
     mock_repo = Mock()
     mock_repo.first.return_value = existing_stock
@@ -83,10 +76,9 @@ def test_handle_movement_created_updates_existing_stock(mock_container):
     updated_stock = Stock(id=1, product_id=10, quantity=105)
     mock_repo.update.return_value = updated_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     events_received = []
 
@@ -98,22 +90,18 @@ def test_handle_movement_created_updates_existing_stock(mock_container):
     event = MovementCreated(
         aggregate_id=2,
         product_id=10,
-        quantity=5,  # Adding 5 units
+        quantity=5,
         type=MovementType.IN.value,
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     mock_repo.first.assert_called_once_with(product_id=10, location_id=None)
     mock_repo.update.assert_called_once()
 
-    # Verify the stock was updated
     updated = mock_repo.update.call_args[0][0]
     assert updated.quantity == 105
 
-    # Verify StockUpdated event was published
     assert len(events_received) == 1
     stock_event = events_received[0]
     assert isinstance(stock_event, StockUpdated)
@@ -123,10 +111,9 @@ def test_handle_movement_created_updates_existing_stock(mock_container):
     assert stock_event.new_quantity == 105
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_decreases_stock_on_out(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_decreases_stock_on_out(mock_create_scope):
     """Test that OUT movement decreases stock"""
-    # Arrange
     existing_stock = Stock(id=1, product_id=10, quantity=100)
     mock_repo = Mock()
     mock_repo.first.return_value = existing_stock
@@ -134,73 +121,63 @@ def test_handle_movement_created_decreases_stock_on_out(mock_container):
     updated_stock = Stock(id=1, product_id=10, quantity=95)
     mock_repo.update.return_value = updated_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     event = MovementCreated(
         aggregate_id=3,
         product_id=10,
-        quantity=-5,  # Removing 5 units
+        quantity=-5,
         type=MovementType.OUT.value,
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     mock_repo.first.assert_called_once_with(product_id=10, location_id=None)
     mock_repo.update.assert_called_once()
 
-    # Verify the stock was decreased
     updated = mock_repo.update.call_args[0][0]
     assert updated.quantity == 95
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_insufficient_stock_raises(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_insufficient_stock_raises(mock_create_scope):
     """Test that insufficient stock raises exception"""
-    # Arrange
     existing_stock = Stock(id=1, product_id=10, quantity=3)
     mock_repo = Mock()
     mock_repo.first.return_value = existing_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     event = MovementCreated(
         aggregate_id=4,
         product_id=10,
-        quantity=-5,  # Trying to remove 5 units but only 3 available
+        quantity=-5,
         type=MovementType.OUT.value,
     )
 
-    # Act & Assert
     with pytest.raises(InsufficientStockError) as exc_info:
         handle_movement_created(event)
 
-    # InsufficientStockError stores product_id in data dict
     assert exc_info.value.data["product_id"] == 10
     mock_repo.update.assert_not_called()
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_publishes_stock_created_event(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_publishes_stock_created_event(mock_create_scope):
     """Test that StockCreated event is published when creating new stock"""
-    # Arrange
     mock_repo = Mock()
     mock_repo.first.return_value = None
 
     new_stock = Stock(id=1, product_id=10, quantity=5)
     mock_repo.create.return_value = new_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     events_received = []
 
@@ -216,10 +193,8 @@ def test_handle_movement_created_publishes_stock_created_event(mock_container):
         type=MovementType.IN.value,
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     assert len(events_received) == 1
     stock_event = events_received[0]
     assert stock_event.aggregate_id == 1
@@ -228,10 +203,9 @@ def test_handle_movement_created_publishes_stock_created_event(mock_container):
     assert stock_event.location_id is None
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_publishes_stock_updated_event(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_publishes_stock_updated_event(mock_create_scope):
     """Test that StockUpdated event is published when updating stock"""
-    # Arrange
     existing_stock = Stock(id=1, product_id=10, quantity=100)
     mock_repo = Mock()
     mock_repo.first.return_value = existing_stock
@@ -239,10 +213,9 @@ def test_handle_movement_created_publishes_stock_updated_event(mock_container):
     updated_stock = Stock(id=1, product_id=10, quantity=105)
     mock_repo.update.return_value = updated_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     events_received = []
 
@@ -258,10 +231,8 @@ def test_handle_movement_created_publishes_stock_updated_event(mock_container):
         type=MovementType.IN.value,
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     assert len(events_received) == 1
     stock_event = events_received[0]
     assert stock_event.aggregate_id == 1
@@ -270,20 +241,18 @@ def test_handle_movement_created_publishes_stock_updated_event(mock_container):
     assert stock_event.new_quantity == 105
 
 
-@patch("src.wireup_container")
-def test_handle_movement_created_with_location(mock_container):
+@patch("src.inventory.stock.infra.event_handlers.create_sync_scope")
+def test_handle_movement_created_with_location(mock_create_scope):
     """Test creating stock with location_id"""
-    # Arrange
     mock_repo = Mock()
     mock_repo.first.return_value = None
 
     new_stock = Stock(id=1, product_id=10, quantity=5, location_id=42)
     mock_repo.create.return_value = new_stock
 
-    # Mock the scope context manager
     mock_scope = Mock()
     mock_scope.get.return_value = mock_repo
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     event = MovementCreated(
         aggregate_id=1,
@@ -292,10 +261,8 @@ def test_handle_movement_created_with_location(mock_container):
         type=MovementType.IN.value,
     )
 
-    # Act
     handle_movement_created(event)
 
-    # Assert
     created_stock = mock_repo.create.call_args[0][0]
     assert created_stock.product_id == 10
     assert created_stock.quantity == 5

--- a/tests/unit/purchasing/test_commands.py
+++ b/tests/unit/purchasing/test_commands.py
@@ -402,7 +402,12 @@ def _make_receipt_handler():
     event_publisher = MagicMock()
     return (
         CreatePurchaseReceiptCommandHandler(
-            po_repo, item_repo, receipt_repo, receipt_item_repo, event_publisher
+            po_repo,
+            item_repo,
+            receipt_repo,
+            receipt_item_repo,
+            event_publisher,
+            MagicMock(),
         ),
         po_repo,
         item_repo,

--- a/tests/unit/purchasing/test_event_handlers.py
+++ b/tests/unit/purchasing/test_event_handlers.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, Mock, patch
 from src.purchasing.domain.events import PurchaseOrderReceived
 
 
-@patch("src.wireup_container")
-def test_handle_purchase_order_received_creates_movements(mock_container):
+@patch("src.purchasing.infra.event_handlers.create_sync_scope")
+def test_handle_purchase_order_received_creates_movements(mock_create_scope):
     """
     Verifies that handle_purchase_order_received creates one IN movement
     per item in the event payload.
@@ -21,7 +21,7 @@ def test_handle_purchase_order_received_creates_movements(mock_container):
     mock_handler = MagicMock()
     mock_scope = Mock()
     mock_scope.get.return_value = mock_handler
-    mock_container.enter_scope.return_value.__enter__.return_value = mock_scope
+    mock_create_scope.return_value.__enter__.return_value = mock_scope
 
     event = PurchaseOrderReceived(
         aggregate_id=1,

--- a/tests/unit/shared/test_events.py
+++ b/tests/unit/shared/test_events.py
@@ -38,20 +38,16 @@ def test_publish_without_subscribers():
     EventBus.publish(OrderCreated(aggregate_id=1, order_total=50.0))
 
 
-def test_handler_error_does_not_stop_others():
-    results = []
+def test_handler_error_propagates_to_caller():
+    """Event handler errors must propagate so the caller can rollback."""
 
     def failing_handler(event: OrderCreated):
         raise RuntimeError("handler failed")
 
-    def working_handler(event: OrderCreated):
-        results.append(event.order_total)
-
     EventBus.subscribe(OrderCreated, failing_handler)
-    EventBus.subscribe(OrderCreated, working_handler)
-    EventBus.publish(OrderCreated(aggregate_id=1, order_total=75.0))
 
-    assert results == [75.0]
+    with pytest.raises(RuntimeError, match="handler failed"):
+        EventBus.publish(OrderCreated(aggregate_id=1, order_total=75.0))
 
 
 def test_clear_removes_all():


### PR DESCRIPTION
## Descripción

   - Upgrade wireup 2.7.0 → 2.9.0 for async_container_force_sync_scope and enter_scope(provided={}) support
   - Fix critical bug: EventBus was swallowing exceptions silently, causing data inconsistency when event handlers failed (e.g., stock update fails but sale still confirms)
   - Fix transactional consistency: event handler chains now share the same DB session via enter_scope(provided={Session: session}), ensuring atomicity across Sale → Movement → Stock operations
   - Fix Kafka handler resource leak: scope was never closed and used private _synchronous_get() API
   - Fix mapper lifetimes: change 31 mappers from transient to singleton since they are stateless

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [ ] Nueva funcionalidad (feature)
- [x] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
