### PR TITLE
fix: use UTC-aware datetime and Z suffix in DomainEvent occurred_at

### DIFF
--- a/src/shared/domain/events.py
+++ b/src/shared/domain/events.py
@@ -1,7 +1,7 @@
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 
@@ -9,7 +9,7 @@ from typing import Any
 class DomainEvent(ABC):
     aggregate_id: int
     event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    occurred_at: datetime = field(default_factory=datetime.now)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
 
     @abstractmethod
     def _payload(self) -> dict[str, Any]:

--- a/src/shared/infra/kafka/event_handlers.py
+++ b/src/shared/infra/kafka/event_handlers.py
@@ -74,7 +74,7 @@ def _build_enriched_payload(event: SaleConfirmed, session: Any = None) -> dict:
         "event_id": event.event_id,
         "event_type": "SaleConfirmed",
         "aggregate_id": event.aggregate_id,
-        "occurred_at": event.occurred_at.isoformat(),
+        "occurred_at": event.occurred_at.isoformat().replace("+00:00", "Z"),
         "payload": {
             "sale_id": event.sale_id,
             "source": event.source,


### PR DESCRIPTION
## Descripción

  Set occurred_at default factory to datetime.now(tz=UTC) so all domain
  events carry timezone info. Serialize to ISO 8601 with Z suffix instead
  of +00:00 for broader compatibility with REST and Kafka consumers.

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [ ] Nueva funcionalidad (feature)
- [x] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
