### PR TITLE
refactor: clean up Scalar docs sidebar with proper tag groups and labels

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -61,40 +61,107 @@ class BaseConfig:
     API_TITLE = "Faclab Core API"
     API_VERSION = "1.0.0"
     API_DESCRIPTION = """
-Faclab Core is a sales and inventory management API.
+**Faclab Core** is a comprehensive sales and inventory management platform.
+It exposes two independent API surfaces — **Admin** for back-office operations
+and **POS** for point-of-sale terminals — both sharing the same underlying
+domain model.
 
-## API Surfaces
+> Use the **sidebar** on the left to navigate by module, or press
+> <kbd>Ctrl</kbd>+<kbd>K</kbd> to search endpoints.
 
-| Surface | Base path | Purpose |
-|---------|-----------|---------|
-| **Admin** | `/api/admin` | Back-office: catalog, inventory, customers, sales reporting |
-| **POS** | `/api/pos` | Point-of-sale: product lookup, customer search, full sales lifecycle |
+---
 
-## Error format
+## API surfaces
+
+| Surface | Base path | Docs | Purpose |
+|---------|-----------|------|---------|
+| **Admin** | `/api/admin` | [`/docs/admin`](/docs/admin) | Back-office: catalog, inventory, warehouses, customers, suppliers, purchasing, sales reporting, and analytics. |
+| **POS** | `/api/pos` | [`/docs/pos`](/docs/pos) | Point-of-sale terminal: product lookup, customer search, shift management, full sales lifecycle, refunds, cash drawer, and operational reports. |
+
+---
+
+## Response format
+
+All successful responses are wrapped in a standard envelope:
 
 ```json
 {
-  "error_code": "DOMAIN_ERROR",
-  "message": "Human-readable description",
-  "timestamp": "2024-01-01T00:00:00Z",
-  "request_id": "uuid",
-  "detail": {}
+  "data": { ... },
+  "meta": {
+    "requestId": "550e8400-e29b-41d4-a716-446655440000",
+    "timestamp": "2025-01-15T10:30:00Z"
+  }
 }
 ```
+
+Paginated lists include additional pagination metadata:
+
+```json
+{
+  "data": [ ... ],
+  "meta": {
+    "requestId": "...",
+    "timestamp": "...",
+    "pagination": { "total": 142, "limit": 100, "offset": 0 }
+  }
+}
+```
+
+---
+
+## Error format
+
+All errors follow a consistent structure with one or more error entries:
+
+```json
+{
+  "errors": [
+    {
+      "code": "NOT_FOUND",
+      "message": "Product with id 99 not found",
+      "field": null
+    }
+  ],
+  "meta": {
+    "requestId": "550e8400-e29b-41d4-a716-446655440000",
+    "timestamp": "2025-01-15T10:30:00Z"
+  }
+}
+```
+
+### HTTP status codes
+
+| Status | Meaning | Typical cause |
+|--------|---------|---------------|
+| **400** | Business rule violation | Domain or application error (e.g. confirming an already-confirmed sale) |
+| **404** | Not found | The requested resource does not exist |
+| **409** | Integrity conflict | Cannot delete/modify because the resource is referenced elsewhere |
+| **422** | Validation error | Request body or query parameters failed validation |
+| **500** | Internal error | Unexpected server-side failure |
+
+---
+
+## Conventions
+
+- **Field naming**: All JSON fields use **camelCase** (e.g. `customerId`, `unitPrice`).
+- **Pagination**: List endpoints accept `limit` (1-1000, default 100) and `offset` (default 0) query parameters.
+- **IDs**: All resource IDs are positive integers.
+- **Decimals**: Monetary and percentage values are returned as floating-point numbers.
+- **Timestamps**: All timestamps are in ISO 8601 format with UTC timezone.
 """
 
     API_OPENAPI_TAGS: list[dict] = [
         # Admin — Catalog
         {
-            "name": "admin - categories",
+            "name": "Categories",
             "description": "Organize the product catalog with a structured category system.",
         },
         {
-            "name": "admin - units of measure",
+            "name": "Units of Measure",
             "description": "Manage units of measure used across products (e.g., kg, liters, units, boxes).",
         },
         {
-            "name": "admin - products",
+            "name": "Products",
             "description": (
                 "Full product catalog management: SKU, pricing, categorization, "
                 "stock thresholds, and service flags."
@@ -102,19 +169,19 @@ Faclab Core is a sales and inventory management API.
         },
         # Admin — Inventory
         {
-            "name": "admin - warehouses",
+            "name": "Warehouses",
             "description": "Manage physical warehouse facilities where inventory is stored.",
         },
         {
-            "name": "admin - locations",
+            "name": "Locations",
             "description": "Manage specific storage locations within warehouses — shelves, bins, and zones.",
         },
         {
-            "name": "admin - stock",
+            "name": "Stock",
             "description": "Query real-time stock levels per product and storage location.",
         },
         {
-            "name": "admin - movements",
+            "name": "Movements",
             "description": (
                 "Record and query inventory movements (IN/OUT). Includes manual entries "
                 "and system-generated movements from confirmed or cancelled sales."
@@ -122,30 +189,30 @@ Faclab Core is a sales and inventory management API.
         },
         # Admin — Customers
         {
-            "name": "admin - customers",
+            "name": "Customers",
             "description": (
                 "Manage customer profiles: tax ID (RUC), credit limits, payment terms, "
                 "and activation status."
             ),
         },
         {
-            "name": "admin - customer-contacts",
+            "name": "Customer Contacts",
             "description": "Manage individual contacts associated with a customer.",
         },
         # Admin — Suppliers
         {
-            "name": "admin - suppliers",
+            "name": "Suppliers",
             "description": (
                 "Manage supplier profiles: tax ID, payment terms, lead times, "
                 "and activation status."
             ),
         },
         {
-            "name": "admin - supplier-contacts",
+            "name": "Supplier Contacts",
             "description": "Manage individual contacts associated with a supplier.",
         },
         {
-            "name": "admin - supplier-products",
+            "name": "Supplier Products",
             "description": (
                 "Manage the purchase catalog: link products to suppliers with "
                 "purchase price, supplier SKU, and minimum order quantity."
@@ -153,53 +220,53 @@ Faclab Core is a sales and inventory management API.
         },
         # Admin — Lots & Serials
         {
-            "name": "admin - lots",
+            "name": "Lots",
             "description": "Lot management — expiry tracking, lot quantities, and perishable product control.",
         },
         {
-            "name": "admin - serials",
+            "name": "Serials",
             "description": "Serial number tracking — unit-level traceability for electronics and equipment.",
         },
         # Admin — Purchasing
         {
-            "name": "admin - purchase-orders",
+            "name": "Purchase Orders",
             "description": "Manage purchase orders: create, send to supplier, receive goods, and cancel.",
         },
         {
-            "name": "admin - purchase-order-items",
+            "name": "Purchase Order Items",
             "description": "Manage line items within a purchase order.",
         },
         # Admin — Adjustments
         {
-            "name": "admin - adjustments",
+            "name": "Adjustments",
             "description": "Manage inventory adjustments — physical counts, corrections, write-offs, and expiration entries.",
         },
         {
-            "name": "admin - adjustment-items",
+            "name": "Adjustment Items",
             "description": "Manage individual line items within an inventory adjustment.",
         },
         # Admin — Transfers
         {
-            "name": "admin - transfers",
+            "name": "Transfers",
             "description": "Manage stock transfers between warehouse locations.",
         },
         {
-            "name": "admin - transfer-items",
+            "name": "Transfer Items",
             "description": "Manage individual line items within a stock transfer.",
         },
         # Admin — Alerts
         {
-            "name": "admin - alerts",
+            "name": "Alerts",
             "description": "Stock level alerts: low stock, out of stock, reorder points, and expiring lots.",
         },
         # Admin — Sales
         {
-            "name": "admin - sales",
+            "name": "Sales",
             "description": "Read-only access to all sales data for back-office reporting and auditing.",
         },
         # Admin — Reports
         {
-            "name": "admin - reports",
+            "name": "Inventory Reports",
             "description": (
                 "Inventory analytics: valuation, product rotation, "
                 "movement history, and warehouse stock summaries."
@@ -207,43 +274,43 @@ Faclab Core is a sales and inventory management API.
         },
         # POS
         {
-            "name": "pos - products",
+            "name": "Product Search",
             "description": "Product lookup for point-of-sale operations.",
         },
         {
-            "name": "pos - customers",
+            "name": "Customer Search",
             "description": "Customer lookup for point-of-sale, including search by tax ID (RUC).",
         },
         {
-            "name": "pos - shifts",
+            "name": "Shifts",
             "description": (
                 "Shift management: open and close cashier shifts, "
                 "track opening/closing balances, and calculate discrepancies."
             ),
         },
         {
-            "name": "pos - sales",
+            "name": "POS Sales",
             "description": (
                 "Full sales lifecycle for the point-of-sale terminal: "
                 "create, add items, confirm, cancel, and register payments."
             ),
         },
         {
-            "name": "pos - refunds",
+            "name": "Refunds",
             "description": (
                 "Process refunds for confirmed sales: create partial/total refunds, "
                 "process payments, and automatically restock inventory."
             ),
         },
         {
-            "name": "pos - cash",
+            "name": "Cash Drawer",
             "description": (
                 "Cash drawer movements: register cash-in/cash-out operations "
                 "within an open shift and query cash summaries."
             ),
         },
         {
-            "name": "pos - reports",
+            "name": "POS Reports",
             "description": (
                 "POS operational reports: X-Report (mid-shift), Z-Report (closing), "
                 "daily sales summary, and sales breakdown by payment method."
@@ -253,72 +320,72 @@ Faclab Core is a sales and inventory management API.
 
     API_TAG_GROUPS: list[dict] = [
         {
-            "name": "Admin — Catalog",
+            "name": "Catalog",
             "tags": [
-                "admin - categories",
-                "admin - units of measure",
-                "admin - products",
+                "Categories",
+                "Units of Measure",
+                "Products",
             ],
         },
         {
-            "name": "Admin — Inventory",
+            "name": "Inventory",
             "tags": [
-                "admin - warehouses",
-                "admin - locations",
-                "admin - stock",
-                "admin - movements",
+                "Warehouses",
+                "Locations",
+                "Stock",
+                "Movements",
             ],
         },
         {
-            "name": "Admin — Lots & Serials",
-            "tags": ["admin - lots", "admin - serials"],
+            "name": "Lots & Serials",
+            "tags": ["Lots", "Serials"],
         },
         {
-            "name": "Admin — Customers",
-            "tags": ["admin - customers", "admin - customer-contacts"],
+            "name": "Customers",
+            "tags": ["Customers", "Customer Contacts"],
         },
         {
-            "name": "Admin — Suppliers",
+            "name": "Suppliers",
             "tags": [
-                "admin - suppliers",
-                "admin - supplier-contacts",
-                "admin - supplier-products",
+                "Suppliers",
+                "Supplier Contacts",
+                "Supplier Products",
             ],
         },
         {
-            "name": "Admin — Purchasing",
-            "tags": ["admin - purchase-orders", "admin - purchase-order-items"],
+            "name": "Purchasing",
+            "tags": ["Purchase Orders", "Purchase Order Items"],
         },
         {
-            "name": "Admin — Adjustments",
-            "tags": ["admin - adjustments", "admin - adjustment-items"],
+            "name": "Adjustments",
+            "tags": ["Adjustments", "Adjustment Items"],
         },
         {
-            "name": "Admin — Transfers",
-            "tags": ["admin - transfers", "admin - transfer-items"],
+            "name": "Transfers",
+            "tags": ["Transfers", "Transfer Items"],
         },
         {
-            "name": "Admin — Alerts",
-            "tags": ["admin - alerts"],
+            "name": "Alerts",
+            "tags": ["Alerts"],
         },
         {
-            "name": "Admin — Sales",
-            "tags": ["admin - sales"],
+            "name": "Sales",
+            "tags": ["Sales"],
         },
         {
-            "name": "Admin — Reports",
-            "tags": ["admin - reports"],
+            "name": "Reports",
+            "tags": ["Inventory Reports"],
         },
         {
             "name": "POS",
             "tags": [
-                "pos - products",
-                "pos - customers",
-                "pos - shifts",
-                "pos - sales",
-                "pos - refunds",
-                "pos - cash",
-                "pos - reports",
+                "Product Search",
+                "Customer Search",
+                "Shifts",
+                "POS Sales",
+                "Refunds",
+                "Cash Drawer",
+                "POS Reports",
             ],
         },
     ]

--- a/main.py
+++ b/main.py
@@ -108,28 +108,38 @@ _SCALAR_TEMPLATE = """<!DOCTYPE html>
 
 
 def _scalar_response(title: str, schema_url: str) -> HTMLResponse:
-    cfg = json.dumps({"layout": "sidebar", "theme": "default", "searchHotKey": "k"})
+    cfg = json.dumps(
+        {
+            "layout": "sidebar",
+            "theme": "default",
+            "searchHotKey": "k",
+            "defaultHttpClient": {
+                "targetKey": "python",
+                "clientKey": "requests",
+            },
+            "withDefaultFonts": True,
+            "hideDownloadButton": False,
+            "hideDarkModeToggle": False,
+        }
+    )
     return HTMLResponse(
         _SCALAR_TEMPLATE.format(title=title, schema_url=schema_url, config=cfg)
     )
 
 
-def _filtered_schema(tag_prefix: str) -> dict:
-    """Return a deepcopy of the full schema containing only operations whose tags start with *tag_prefix*."""
+def _filtered_schema(path_prefix: str) -> dict:
+    """Return a deepcopy of the full schema containing only operations whose paths start with *path_prefix*."""
     schema = copy.deepcopy(app.openapi())
     used_tags: set[str] = set()
     filtered_paths: dict = {}
 
     for path, path_item in schema.get("paths", {}).items():
-        filtered_ops: dict = {}
-        for method, operation in path_item.items():
-            if isinstance(operation, dict) and any(
-                t.startswith(tag_prefix) for t in operation.get("tags", [])
-            ):
-                filtered_ops[method] = operation
+        if not path.startswith(path_prefix):
+            continue
+        filtered_paths[path] = path_item
+        for _method, operation in path_item.items():
+            if isinstance(operation, dict):
                 used_tags.update(operation.get("tags", []))
-        if filtered_ops:
-            filtered_paths[path] = filtered_ops
 
     schema["paths"] = filtered_paths
     schema["tags"] = [t for t in schema.get("tags", []) if t["name"] in used_tags]
@@ -158,113 +168,103 @@ src.wireup_container = wireup_container
 # Admin API
 admin_router = APIRouter(prefix="/api/admin")
 admin_router.include_router(
-    CategoryRouter().router, prefix="/categories", tags=["admin - categories"]
+    CategoryRouter().router, prefix="/categories", tags=["Categories"]
 )
 admin_router.include_router(
     UnitOfMeasureRouter().router,
     prefix="/units-of-measure",
-    tags=["admin - units of measure"],
+    tags=["Units of Measure"],
 )
 admin_router.include_router(
-    ProductRouter().router, prefix="/products", tags=["admin - products"]
+    ProductRouter().router, prefix="/products", tags=["Products"]
 )
 admin_router.include_router(
-    WarehouseRouter().router, prefix="/warehouses", tags=["admin - warehouses"]
+    WarehouseRouter().router, prefix="/warehouses", tags=["Warehouses"]
 )
 admin_router.include_router(
-    LocationRouter().router, prefix="/locations", tags=["admin - locations"]
+    LocationRouter().router, prefix="/locations", tags=["Locations"]
 )
+admin_router.include_router(StockRouter().router, prefix="/stock", tags=["Stock"])
 admin_router.include_router(
-    StockRouter().router, prefix="/stock", tags=["admin - stock"]
+    MovementRouter().router, prefix="/movements", tags=["Movements"]
 )
+admin_router.include_router(LotRouter().router, prefix="/lots", tags=["Lots"])
+admin_router.include_router(SerialRouter().router, prefix="/serials", tags=["Serials"])
 admin_router.include_router(
-    MovementRouter().router, prefix="/movements", tags=["admin - movements"]
-)
-admin_router.include_router(LotRouter().router, prefix="/lots", tags=["admin - lots"])
-admin_router.include_router(
-    SerialRouter().router, prefix="/serials", tags=["admin - serials"]
-)
-admin_router.include_router(
-    CustomerRouter().router, prefix="/customers", tags=["admin - customers"]
+    CustomerRouter().router, prefix="/customers", tags=["Customers"]
 )
 admin_router.include_router(
     CustomerContactRouter().router,
     prefix="/customer-contacts",
-    tags=["admin - customer-contacts"],
+    tags=["Customer Contacts"],
 )
 admin_router.include_router(
-    SupplierRouter().router, prefix="/suppliers", tags=["admin - suppliers"]
+    SupplierRouter().router, prefix="/suppliers", tags=["Suppliers"]
 )
 admin_router.include_router(
     SupplierContactRouter().router,
     prefix="/supplier-contacts",
-    tags=["admin - supplier-contacts"],
+    tags=["Supplier Contacts"],
 )
 admin_router.include_router(
     SupplierProductRouter().router,
     prefix="/supplier-products",
-    tags=["admin - supplier-products"],
+    tags=["Supplier Products"],
 )
 admin_router.include_router(
     PurchaseOrderRouter().router,
     prefix="/purchase-orders",
-    tags=["admin - purchase-orders"],
+    tags=["Purchase Orders"],
 )
 admin_router.include_router(
     POItemRouter().router,
     prefix="/purchase-order-items",
-    tags=["admin - purchase-order-items"],
+    tags=["Purchase Order Items"],
 )
-admin_router.include_router(
-    SaleRouter().router, prefix="/sales", tags=["admin - sales"]
-)
+admin_router.include_router(SaleRouter().router, prefix="/sales", tags=["Sales"])
 admin_router.include_router(
     AdjustmentRouter().router,
     prefix="/adjustments",
-    tags=["admin - adjustments"],
+    tags=["Adjustments"],
 )
 admin_router.include_router(
     AdjustmentItemRouter().router,
     prefix="/adjustment-items",
-    tags=["admin - adjustment-items"],
+    tags=["Adjustment Items"],
 )
 admin_router.include_router(
     TransferRouter().router,
     prefix="/transfers",
-    tags=["admin - transfers"],
+    tags=["Transfers"],
 )
 admin_router.include_router(
     TransferItemRouter().router,
     prefix="/transfer-items",
-    tags=["admin - transfer-items"],
+    tags=["Transfer Items"],
 )
-admin_router.include_router(
-    AlertRouter().router, prefix="/alerts", tags=["admin - alerts"]
-)
+admin_router.include_router(AlertRouter().router, prefix="/alerts", tags=["Alerts"])
 admin_router.include_router(
     ReportRouter().router,
     prefix="/reports/inventory",
-    tags=["admin - reports"],
+    tags=["Inventory Reports"],
 )
 
 # POS API
 pos_router = APIRouter(prefix="/api/pos")
-pos_router.include_router(POSSaleRouter().router, prefix="/sales", tags=["pos - sales"])
+pos_router.include_router(POSSaleRouter().router, prefix="/sales", tags=["POS Sales"])
+pos_router.include_router(POSShiftRouter().router, prefix="/shifts", tags=["Shifts"])
 pos_router.include_router(
-    POSShiftRouter().router, prefix="/shifts", tags=["pos - shifts"]
+    POSProductRouter().router, prefix="/products", tags=["Product Search"]
 )
 pos_router.include_router(
-    POSProductRouter().router, prefix="/products", tags=["pos - products"]
+    POSCustomerRouter().router, prefix="/customers", tags=["Customer Search"]
+)
+pos_router.include_router(POSRefundRouter().router, prefix="/refunds", tags=["Refunds"])
+pos_router.include_router(
+    POSCashRouter().router, prefix="/shifts", tags=["Cash Drawer"]
 )
 pos_router.include_router(
-    POSCustomerRouter().router, prefix="/customers", tags=["pos - customers"]
-)
-pos_router.include_router(
-    POSRefundRouter().router, prefix="/refunds", tags=["pos - refunds"]
-)
-pos_router.include_router(POSCashRouter().router, prefix="/shifts", tags=["pos - cash"])
-pos_router.include_router(
-    POSReportRouter().router, prefix="/reports", tags=["pos - reports"]
+    POSReportRouter().router, prefix="/reports", tags=["POS Reports"]
 )
 
 # ---------------------------------------------------------------------------
@@ -306,11 +306,11 @@ if _docs.enabled:
 
     @app.get("/openapi/admin.json", include_in_schema=False)
     async def admin_openapi_schema():
-        return JSONResponse(_filtered_schema("admin"))
+        return JSONResponse(_filtered_schema("/api/admin"))
 
     @app.get("/openapi/pos.json", include_in_schema=False)
     async def pos_openapi_schema():
-        return JSONResponse(_filtered_schema("pos"))
+        return JSONResponse(_filtered_schema("/api/pos"))
 
 
 # ---------------------------------------------------------------------------

--- a/src/catalog/product/infra/routes.py
+++ b/src/catalog/product/infra/routes.py
@@ -46,7 +46,15 @@ from src.catalog.product.infra.validators import (
     ProductResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class CategoryRouter:
@@ -57,23 +65,31 @@ class CategoryRouter:
     def _setup_routes(self):
         """Sets up all the routes for the router."""
         self.router.post(
-            "", response_model=DataResponse[CategoryResponse], summary="Save category"
+            "",
+            response_model=DataResponse[CategoryResponse],
+            summary="Save category",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[CategoryResponse],
             summary="Update category",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete category")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete category", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[CategoryResponse],
             summary="Get all categories",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CategoryResponse],
             summary="Get category by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(
@@ -145,23 +161,31 @@ class ProductRouter:
     def _setup_routes(self):
         """Sets up all the routes for the router."""
         self.router.post(
-            "", response_model=DataResponse[ProductResponse], summary="Save product"
+            "",
+            response_model=DataResponse[ProductResponse],
+            summary="Save product",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Update product",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete product")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete product", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[ProductResponse],
             summary="Get all products",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Get product by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(

--- a/src/catalog/product/infra/validators.py
+++ b/src/catalog/product/infra/validators.py
@@ -8,37 +8,77 @@ from src.shared.infra.validators import DecimalNumber, QueryParams
 
 # Requests
 class CategoryRequest(BaseModel):
-    name: str
-    description: str | None = None
+    name: str = Field(description="Category name")
+    description: str | None = Field(None, description="Optional description")
 
 
 class ProductRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    name: str
-    sku: str
-    description: str | None = None
-    barcode: str | None = None
-    category_id: int | None = Field(None, ge=1)
-    unit_of_measure_id: int | None = Field(None, ge=1)
-    purchase_price: DecimalNumber | None = Field(None, ge=0)
-    sale_price: DecimalNumber | None = Field(None, ge=0)
-    tax_rate: DecimalNumber = Field(Decimal("15.00"), ge=0, le=100)
-    is_active: bool = True
-    is_service: bool = False
-    min_stock: int = Field(0, ge=0)
-    max_stock: int | None = Field(None, ge=0)
-    reorder_point: int = Field(0, ge=0)
-    lead_time_days: int | None = Field(None, ge=0)
+    name: str = Field(description="Product name")
+    sku: str = Field(description="Stock Keeping Unit — unique product code")
+    description: str | None = Field(None, description="Product description")
+    barcode: str | None = Field(None, description="Barcode (EAN/UPC)")
+    category_id: int | None = Field(None, ge=1, description="Category ID")
+    unit_of_measure_id: int | None = Field(None, ge=1, description="Unit of measure ID")
+    purchase_price: DecimalNumber | None = Field(
+        None, ge=0, description="Purchase price per unit"
+    )
+    sale_price: DecimalNumber | None = Field(
+        None, ge=0, description="Sale price per unit"
+    )
+    tax_rate: DecimalNumber = Field(
+        Decimal("15.00"), ge=0, le=100, description="Tax rate percentage (0-100)"
+    )
+    is_active: bool = Field(True, description="Whether the product is active")
+    is_service: bool = Field(
+        False, description="True if this is a service (no inventory tracking)"
+    )
+    min_stock: int = Field(
+        0, ge=0, description="Minimum stock level — triggers low-stock alert"
+    )
+    max_stock: int | None = Field(
+        None, ge=0, description="Maximum recommended stock level"
+    )
+    reorder_point: int = Field(0, ge=0, description="Stock level at which to reorder")
+    lead_time_days: int | None = Field(
+        None, ge=0, description="Supplier lead time in days"
+    )
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        json_schema_extra={
+            "examples": [
+                {
+                    "name": "Laptop Dell Inspiron 15",
+                    "sku": "DELL-INS-15",
+                    "description": "Dell Inspiron 15 laptop, 16GB RAM, 512GB SSD",
+                    "barcode": "7501234567890",
+                    "categoryId": 1,
+                    "unitOfMeasureId": 1,
+                    "purchasePrice": 650.00,
+                    "salePrice": 899.99,
+                    "taxRate": 15.00,
+                    "isActive": True,
+                    "isService": False,
+                    "minStock": 5,
+                    "maxStock": 50,
+                    "reorderPoint": 10,
+                    "leadTimeDays": 7,
+                }
+            ]
+        },
+    )
 
 
 # Responses
 class CategoryResponse(CategoryRequest):
-    id: int = Field(ge=1)
+    id: int = Field(ge=1, description="Category ID")
 
 
 class ProductResponse(ProductRequest):
-    id: int = Field(ge=1)
+    id: int = Field(ge=1, description="Product ID")
 
 
 # Query Params
@@ -47,4 +87,4 @@ class CategoryQueryParams(QueryParams):
 
 
 class ProductQueryParams(QueryParams):
-    category_id: int | None = Field(None, ge=1)
+    category_id: int | None = Field(None, ge=1, description="Filter by category ID")

--- a/src/catalog/uom/infra/routes.py
+++ b/src/catalog/uom/infra/routes.py
@@ -25,7 +25,15 @@ from src.catalog.uom.infra.validators import (
     UnitOfMeasureResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class UnitOfMeasureRouter:
@@ -38,22 +46,28 @@ class UnitOfMeasureRouter:
             "",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Create unit of measure",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Update unit of measure",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete unit of measure")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete unit of measure", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[UnitOfMeasureResponse],
             summary="Get all units of measure",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Get unit of measure by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(
@@ -62,6 +76,7 @@ class UnitOfMeasureRouter:
         handler: Injected[CreateUnitOfMeasureCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[UnitOfMeasureResponse]:
+        """Create a new unit of measure (e.g. kg, unit, box)."""
         result = handler.handle(
             CreateUnitOfMeasureCommand(**body.model_dump(by_alias=False))
         )
@@ -76,6 +91,7 @@ class UnitOfMeasureRouter:
         handler: Injected[UpdateUnitOfMeasureCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[UnitOfMeasureResponse]:
+        """Update a unit of measure."""
         result = handler.handle(
             UpdateUnitOfMeasureCommand(uom_id=id, **body.model_dump(by_alias=False))
         )
@@ -86,6 +102,7 @@ class UnitOfMeasureRouter:
     def delete(
         self, id: int, handler: Injected[DeleteUnitOfMeasureCommandHandler]
     ) -> None:
+        """Delete a unit of measure. Fails if products reference it."""
         handler.handle(DeleteUnitOfMeasureCommand(uom_id=id))
 
     def get_all(
@@ -94,6 +111,7 @@ class UnitOfMeasureRouter:
         query_params: UnitOfMeasureQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[UnitOfMeasureResponse]:
+        """List all units of measure. Supports pagination."""
         result = handler.handle(
             GetAllUnitsOfMeasureQuery(**query_params.model_dump(exclude_none=True))
         )
@@ -112,6 +130,7 @@ class UnitOfMeasureRouter:
         handler: Injected[GetUnitOfMeasureByIdQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[UnitOfMeasureResponse]:
+        """Retrieve a unit of measure by its ID."""
         result = handler.handle(GetUnitOfMeasureByIdQuery(uom_id=id))
         return DataResponse(
             data=UnitOfMeasureResponse.model_validate(result), meta=meta

--- a/src/catalog/uom/infra/validators.py
+++ b/src/catalog/uom/infra/validators.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from src.shared.infra.validators import QueryParams
@@ -7,22 +7,22 @@ from src.shared.infra.validators import QueryParams
 class UnitOfMeasureRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    name: str
-    symbol: str
-    description: str | None = None
-    is_active: bool = True
+    name: str = Field(description="Unit name (e.g. Kilogram, Liter, Box)")
+    symbol: str = Field(description="Abbreviation (e.g. kg, L, box)")
+    description: str | None = Field(None, description="Optional description")
+    is_active: bool = Field(True, description="Whether the unit is active")
 
 
 class UnitOfMeasureResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    name: str
-    symbol: str
-    description: str | None = None
-    is_active: bool
+    id: int = Field(description="Unit of measure ID")
+    name: str = Field(description="Unit name")
+    symbol: str = Field(description="Abbreviation")
+    description: str | None = Field(None, description="Optional description")
+    is_active: bool = Field(description="Whether the unit is active")
 
 
 # Query Params
 class UnitOfMeasureQueryParams(QueryParams):
-    is_active: bool | None = None
+    is_active: bool | None = Field(None, description="Filter by active status")

--- a/src/customers/infra/routes.py
+++ b/src/customers/infra/routes.py
@@ -44,6 +44,10 @@ from src.customers.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -62,47 +66,58 @@ class CustomerRouter:
             "",
             response_model=DataResponse[CustomerResponse],
             summary="Create customer",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Update customer",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete customer")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete customer", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[CustomerResponse],
             summary="Get all customers",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.get(
             "/search/by-tax-id",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer by tax ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_tax_id)
         self.router.post(
             "/{id}/activate",
             response_model=DataResponse[CustomerResponse],
             summary="Activate customer",
+            responses=RESPONSES_COMMAND,
         )(self.activate)
         self.router.post(
             "/{id}/deactivate",
             response_model=DataResponse[CustomerResponse],
             summary="Deactivate customer",
+            responses=RESPONSES_COMMAND,
         )(self.deactivate)
         self.router.post(
             "/{customer_id}/contacts",
             response_model=DataResponse[CustomerContactResponse],
             summary="Create customer contact",
+            responses=RESPONSES_COMMAND,
         )(self.create_contact)
         self.router.get(
             "/{customer_id}/contacts",
             response_model=ListResponse[CustomerContactResponse],
             summary="Get customer contacts",
+            responses=RESPONSES_LIST,
         )(self.get_customer_contacts)
 
     def create(
@@ -239,12 +254,16 @@ class CustomerContactRouter:
             "/{id}",
             response_model=DataResponse[CustomerContactResponse],
             summary="Update customer contact",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete customer contact")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete customer contact", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerContactResponse],
             summary="Get customer contact by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def update(

--- a/src/inventory/adjustment/infra/routes.py
+++ b/src/inventory/adjustment/infra/routes.py
@@ -38,6 +38,10 @@ from src.inventory.adjustment.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -55,44 +59,55 @@ class AdjustmentRouter:
             "",
             response_model=PaginatedDataResponse[AdjustmentResponse],
             summary="Get all adjustments",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.post(
             "",
             response_model=DataResponse[AdjustmentResponse],
             summary="Create adjustment",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.get(
             "/{id}",
             response_model=DataResponse[AdjustmentResponse],
             summary="Get adjustment by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.put(
             "/{id}",
             response_model=DataResponse[AdjustmentResponse],
             summary="Update adjustment",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", status_code=204, summary="Delete adjustment")(
-            self.delete
-        )
+        self.router.delete(
+            "/{id}",
+            status_code=204,
+            summary="Delete adjustment",
+            responses=RESPONSES_DELETE,
+        )(self.delete)
         self.router.post(
             "/{id}/confirm",
             response_model=DataResponse[AdjustmentResponse],
             summary="Confirm adjustment",
+            responses=RESPONSES_COMMAND,
         )(self.confirm)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[AdjustmentResponse],
             summary="Cancel adjustment",
+            responses=RESPONSES_COMMAND,
         )(self.cancel)
         self.router.post(
             "/{id}/items",
             response_model=DataResponse[AdjustmentItemResponse],
             summary="Add item to adjustment",
+            responses=RESPONSES_COMMAND,
         )(self.add_item)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[AdjustmentItemResponse],
             summary="Get adjustment items",
+            responses=RESPONSES_LIST,
         )(self.get_items)
 
     def get_all(
@@ -223,10 +238,14 @@ class AdjustmentItemRouter:
             "/{id}",
             response_model=DataResponse[AdjustmentItemResponse],
             summary="Update adjustment item",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", status_code=204, summary="Remove adjustment item")(
-            self.remove
-        )
+        self.router.delete(
+            "/{id}",
+            status_code=204,
+            summary="Remove adjustment item",
+            responses=RESPONSES_DELETE,
+        )(self.remove)
 
     def update(
         self,

--- a/src/inventory/adjustment/infra/validators.py
+++ b/src/inventory/adjustment/infra/validators.py
@@ -3,69 +3,80 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from src.inventory.adjustment.domain.entities import AdjustmentReason, AdjustmentStatus
 from src.shared.infra.validators import QueryParams
 
 
 class CreateAdjustmentRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int
-    reason: str
-    notes: str | None = None
-    adjusted_by: str | None = None
+    warehouse_id: int = Field(description="ID of the warehouse being adjusted")
+    reason: AdjustmentReason = Field(description="Reason for the adjustment")
+    notes: str | None = Field(None, description="Additional notes")
+    adjusted_by: str | None = Field(
+        None, description="Name of the person performing the adjustment"
+    )
 
 
 class UpdateAdjustmentRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    notes: str | None = None
-    adjusted_by: str | None = None
+    notes: str | None = Field(None, description="Additional notes")
+    adjusted_by: str | None = Field(
+        None, description="Name of the person performing the adjustment"
+    )
 
 
 class AddAdjustmentItemRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    product_id: int
-    location_id: int
-    actual_quantity: int
-    lot_id: int | None = None
-    notes: str | None = None
+    product_id: int = Field(description="Product ID to adjust")
+    location_id: int = Field(description="Storage location ID")
+    actual_quantity: int = Field(description="Actual counted quantity")
+    lot_id: int | None = Field(None, description="Lot ID (if applicable)")
+    notes: str | None = Field(None, description="Notes for this item")
 
 
 class UpdateAdjustmentItemRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    actual_quantity: int | None = None
-    notes: str | None = None
+    actual_quantity: int | None = Field(None, description="Corrected actual quantity")
+    notes: str | None = Field(None, description="Updated notes")
 
 
 class AdjustmentResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    warehouse_id: int
-    reason: str
-    status: str
-    adjustment_date: datetime | None = None
-    notes: str | None = None
-    adjusted_by: str | None = None
-    created_at: datetime | None = None
+    id: int = Field(description="Adjustment ID")
+    warehouse_id: int = Field(description="Warehouse ID")
+    reason: AdjustmentReason = Field(description="Reason for the adjustment")
+    status: AdjustmentStatus = Field(description="Current adjustment status")
+    adjustment_date: datetime | None = Field(None, description="Date of the adjustment")
+    notes: str | None = Field(None, description="Additional notes")
+    adjusted_by: str | None = Field(
+        None, description="Person who performed the adjustment"
+    )
+    created_at: datetime | None = Field(None, description="Record creation timestamp")
 
 
 class AdjustmentItemResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    adjustment_id: int
-    product_id: int
-    location_id: int
-    expected_quantity: int
-    actual_quantity: int
-    difference: int
-    lot_id: int | None = None
-    notes: str | None = None
+    id: int = Field(description="Adjustment item ID")
+    adjustment_id: int = Field(description="Parent adjustment ID")
+    product_id: int = Field(description="Product ID")
+    location_id: int = Field(description="Storage location ID")
+    expected_quantity: int = Field(
+        description="System-recorded quantity before adjustment"
+    )
+    actual_quantity: int = Field(description="Actual counted quantity")
+    difference: int = Field(description="Difference (actual - expected)")
+    lot_id: int | None = Field(None, description="Lot ID (if applicable)")
+    notes: str | None = Field(None, description="Notes for this item")
 
 
 class AdjustmentQueryParams(QueryParams):
-    status: str | None = None
-    warehouse_id: int | None = Field(None, ge=1)
+    status: AdjustmentStatus | None = Field(
+        None, description="Filter by adjustment status"
+    )
+    warehouse_id: int | None = Field(None, ge=1, description="Filter by warehouse ID")

--- a/src/inventory/alert/infra/routes.py
+++ b/src/inventory/alert/infra/routes.py
@@ -17,7 +17,7 @@ from src.inventory.alert.infra.validators import (
     StockAlertResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import ListResponse, Meta
+from src.shared.infra.validators import RESPONSES_LIST, ListResponse, Meta
 
 
 class AlertRouter:
@@ -30,21 +30,25 @@ class AlertRouter:
             "/low-stock",
             response_model=ListResponse[StockAlertResponse],
             summary="Get low stock alerts",
+            responses=RESPONSES_LIST,
         )(self.low_stock)
         self.router.get(
             "/out-of-stock",
             response_model=ListResponse[StockAlertResponse],
             summary="Get out of stock alerts",
+            responses=RESPONSES_LIST,
         )(self.out_of_stock)
         self.router.get(
             "/reorder-point",
             response_model=ListResponse[StockAlertResponse],
             summary="Get reorder point alerts",
+            responses=RESPONSES_LIST,
         )(self.reorder_point)
         self.router.get(
             "/expiring-lots",
             response_model=ListResponse[StockAlertResponse],
             summary="Get expiring lots alerts",
+            responses=RESPONSES_LIST,
         )(self.expiring_lots)
 
     def low_stock(

--- a/src/inventory/alert/infra/validators.py
+++ b/src/inventory/alert/infra/validators.py
@@ -1,26 +1,34 @@
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from src.inventory.alert.domain.types import AlertType
+
 
 class StockAlertResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    type: str
-    product_id: int
-    product_name: str
-    sku: str
-    current_quantity: int
-    threshold: int
-    warehouse_id: int | None = None
-    lot_id: int | None = None
-    days_to_expiry: int | None = None
+    type: AlertType = Field(description="Type of stock alert")
+    product_id: int = Field(description="Product ID")
+    product_name: str = Field(description="Product name")
+    sku: str = Field(description="Product SKU")
+    current_quantity: int = Field(description="Current stock quantity")
+    threshold: int = Field(description="Alert threshold that was breached")
+    warehouse_id: int | None = Field(
+        None, description="Warehouse ID (if location-specific)"
+    )
+    lot_id: int | None = Field(None, description="Lot ID (for expiration alerts)")
+    days_to_expiry: int | None = Field(
+        None, description="Days until expiration (for expiring lots)"
+    )
 
 
 class StockAlertQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int | None = Field(None, ge=1)
+    warehouse_id: int | None = Field(None, ge=1, description="Filter by warehouse ID")
 
 
 class ExpiringLotsQueryParams(BaseModel):
-    days: int = Field(30, ge=1)
+    days: int = Field(
+        30, ge=1, description="Number of days to look ahead for expiring lots"
+    )

--- a/src/inventory/location/infra/routes.py
+++ b/src/inventory/location/infra/routes.py
@@ -21,7 +21,15 @@ from src.inventory.location.app.queries.get_location import (
 )
 from src.inventory.location.infra.validators import LocationRequest, LocationResponse
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, ListResponse, Meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    ListResponse,
+    Meta,
+)
 
 
 class LocationRouter:
@@ -34,22 +42,28 @@ class LocationRouter:
             "",
             response_model=DataResponse[LocationResponse],
             summary="Create location",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[LocationResponse],
             summary="Update location",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete location")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete location", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=ListResponse[LocationResponse],
             summary="Get all locations",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[LocationResponse],
             summary="Get location by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(
@@ -58,6 +72,7 @@ class LocationRouter:
         handler: Injected[CreateLocationCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[LocationResponse]:
+        """Create a storage location within a warehouse."""
         result = handler.handle(
             CreateLocationCommand(**body.model_dump(by_alias=False))
         )
@@ -70,12 +85,14 @@ class LocationRouter:
         handler: Injected[UpdateLocationCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[LocationResponse]:
+        """Update a storage location."""
         result = handler.handle(
             UpdateLocationCommand(location_id=id, **body.model_dump(by_alias=False))
         )
         return DataResponse(data=LocationResponse.model_validate(result), meta=meta)
 
     def delete(self, id: int, handler: Injected[DeleteLocationCommandHandler]) -> None:
+        """Delete a storage location. Fails if stock exists at this location."""
         handler.handle(DeleteLocationCommand(location_id=id))
 
     def get_all(
@@ -85,6 +102,7 @@ class LocationRouter:
         is_active: bool | None = None,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[LocationResponse]:
+        """List all storage locations. Optionally filter by warehouse or active status."""
         result = handler.handle(
             GetAllLocationsQuery(warehouse_id=warehouse_id, is_active=is_active)
         )
@@ -98,5 +116,6 @@ class LocationRouter:
         handler: Injected[GetLocationByIdQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[LocationResponse]:
+        """Retrieve a storage location by its ID."""
         result = handler.handle(GetLocationByIdQuery(location_id=id))
         return DataResponse(data=LocationResponse.model_validate(result), meta=meta)

--- a/src/inventory/location/infra/validators.py
+++ b/src/inventory/location/infra/validators.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from src.inventory.location.domain.entities import LocationType
@@ -7,21 +7,25 @@ from src.inventory.location.domain.entities import LocationType
 class LocationRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int
-    name: str
-    code: str
-    type: LocationType = LocationType.STORAGE
-    is_active: bool = True
-    capacity: int | None = None
+    warehouse_id: int = Field(description="ID of the parent warehouse")
+    name: str = Field(description="Location name (e.g. Shelf A1)")
+    code: str = Field(description="Unique location code within the warehouse")
+    type: LocationType = Field(
+        LocationType.STORAGE, description="Location type / purpose"
+    )
+    is_active: bool = Field(True, description="Whether the location is active")
+    capacity: int | None = Field(
+        None, ge=0, description="Maximum storage capacity in units"
+    )
 
 
 class LocationResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    warehouse_id: int
-    name: str
-    code: str
-    type: LocationType
-    is_active: bool
-    capacity: int | None = None
+    id: int = Field(description="Location ID")
+    warehouse_id: int = Field(description="ID of the parent warehouse")
+    name: str = Field(description="Location name")
+    code: str = Field(description="Unique location code")
+    type: LocationType = Field(description="Location type / purpose")
+    is_active: bool = Field(description="Whether the location is active")
+    capacity: int | None = Field(None, description="Maximum storage capacity in units")

--- a/src/inventory/lot/infra/routes.py
+++ b/src/inventory/lot/infra/routes.py
@@ -20,7 +20,14 @@ from src.inventory.lot.infra.validators import (
     LotUpdateRequest,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class LotRouter:
@@ -33,21 +40,25 @@ class LotRouter:
             "",
             response_model=DataResponse[LotResponse],
             summary="Create lot",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[LotResponse],
             summary="Update lot",
+            responses=RESPONSES_COMMAND,
         )(self.update)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[LotResponse],
             summary="Get lots",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[LotResponse],
             summary="Get lot by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(

--- a/src/inventory/movement/infra/routes.py
+++ b/src/inventory/movement/infra/routes.py
@@ -15,7 +15,13 @@ from src.inventory.movement.infra.validators import (
     MovementResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class MovementRouter:
@@ -29,11 +35,13 @@ class MovementRouter:
             "",
             response_model=DataResponse[MovementResponse],
             summary="Save movement",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[MovementResponse],
             summary="Get all movements",
+            responses=RESPONSES_LIST,
         )(self.get_all)
 
     def create(
@@ -42,7 +50,7 @@ class MovementRouter:
         handler: Injected[CreateMovementCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[MovementResponse]:
-        """Save a new movement."""
+        """Create a manual inventory movement (IN or OUT). Stock is updated automatically."""
         result = handler.handle(
             CreateMovementCommand(**new_movement.model_dump(exclude_none=True))
         )
@@ -54,7 +62,7 @@ class MovementRouter:
         query_params: MovementQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[MovementResponse]:
-        """Get all movements."""
+        """List all inventory movements with optional filtering. Supports pagination."""
         result = handler.handle(
             GetAllMovementsQuery(**query_params.model_dump(exclude_none=True))
         )

--- a/src/inventory/serial/infra/routes.py
+++ b/src/inventory/serial/infra/routes.py
@@ -20,7 +20,14 @@ from src.inventory.serial.infra.validators import (
     SerialStatusUpdateRequest,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class SerialRouter:
@@ -33,21 +40,25 @@ class SerialRouter:
             "",
             response_model=DataResponse[SerialNumberResponse],
             summary="Create serial number",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[SerialNumberResponse],
             summary="Get serial numbers",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SerialNumberResponse],
             summary="Get serial number by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.put(
             "/{id}/status",
             response_model=DataResponse[SerialNumberResponse],
             summary="Update serial number status",
+            responses=RESPONSES_COMMAND,
         )(self.update_status)
 
     def create(

--- a/src/inventory/serial/infra/validators.py
+++ b/src/inventory/serial/infra/validators.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Literal
 
 from pydantic import AliasChoices, BaseModel, Field
 
+from src.inventory.serial.domain.entities import SerialStatus
 from src.shared.infra.validators import QueryParams
 
 
@@ -39,9 +39,7 @@ class SerialNumberRequest(BaseModel):
 
 
 class SerialStatusUpdateRequest(BaseModel):
-    status: Literal["available", "reserved", "sold", "returned", "scrapped"] = Field(
-        ..., description="New status for the serial number"
-    )
+    status: SerialStatus = Field(..., description="New status for the serial number")
 
 
 class SerialNumberResponse(BaseModel):
@@ -55,7 +53,7 @@ class SerialNumberResponse(BaseModel):
         validation_alias=AliasChoices("serialNumber", "serial_number"),
         serialization_alias="serialNumber",
     )
-    status: str
+    status: SerialStatus = Field(description="Current serial number status")
     lot_id: int | None = Field(
         None,
         validation_alias=AliasChoices("lotId", "lot_id"),
@@ -86,5 +84,5 @@ class SerialNumberResponse(BaseModel):
 
 # Query Params
 class SerialQueryParams(QueryParams):
-    product_id: int | None = Field(None, ge=1)
-    status: str | None = None
+    product_id: int | None = Field(None, ge=1, description="Filter by product ID")
+    status: SerialStatus | None = Field(None, description="Filter by serial status")

--- a/src/inventory/stock/infra/routes.py
+++ b/src/inventory/stock/infra/routes.py
@@ -7,7 +7,7 @@ from src.inventory.stock.app.queries.stock import (
 )
 from src.inventory.stock.infra.validators import StockQueryParams, StockResponse
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import Meta, PaginatedDataResponse
+from src.shared.infra.validators import RESPONSES_LIST, Meta, PaginatedDataResponse
 
 
 class StockRouter:
@@ -21,6 +21,7 @@ class StockRouter:
             "",
             response_model=PaginatedDataResponse[StockResponse],
             summary="Get all stocks",
+            responses=RESPONSES_LIST,
         )(self.get_all)
 
     def get_all(
@@ -29,7 +30,7 @@ class StockRouter:
         query_params: StockQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[StockResponse]:
-        """Gets all products stock."""
+        """List current stock levels per product and location. Supports filtering and pagination."""
         result = handler.handle(
             GetAllStocksQuery(**query_params.model_dump(exclude_none=True))
         )

--- a/src/inventory/stock/infra/validators.py
+++ b/src/inventory/stock/infra/validators.py
@@ -4,7 +4,7 @@ from src.shared.infra.validators import QueryParams
 
 
 class StockResponse(BaseModel):
-    id: int
+    id: int = Field(description="Stock record ID")
     product_id: int = Field(
         ...,
         ge=1,
@@ -12,19 +12,21 @@ class StockResponse(BaseModel):
         validation_alias=AliasChoices("productId", "product_id"),
         serialization_alias="productId",
     )
-    quantity: int
+    quantity: int = Field(description="Current stock quantity on hand")
     location_id: int | None = Field(
         None,
+        description="Storage location ID",
         validation_alias=AliasChoices("locationId", "location_id"),
         serialization_alias="locationId",
     )
     reserved_quantity: int = Field(
         0,
+        description="Quantity reserved for confirmed transfers or orders",
         validation_alias=AliasChoices("reservedQuantity", "reserved_quantity"),
         serialization_alias="reservedQuantity",
     )
 
 
 class StockQueryParams(QueryParams):
-    product_id: int | None = Field(None, ge=1)
-    location_id: int | None = Field(None, ge=1)
+    product_id: int | None = Field(None, ge=1, description="Filter by product ID")
+    location_id: int | None = Field(None, ge=1, description="Filter by location ID")

--- a/src/inventory/transfer/infra/routes.py
+++ b/src/inventory/transfer/infra/routes.py
@@ -40,6 +40,10 @@ from src.inventory.transfer.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -57,49 +61,61 @@ class TransferRouter:
             "",
             response_model=PaginatedDataResponse[TransferResponse],
             summary="Get all transfers",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.post(
             "",
             response_model=DataResponse[TransferResponse],
             summary="Create transfer",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.get(
             "/{id}",
             response_model=DataResponse[TransferResponse],
             summary="Get transfer by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.put(
             "/{id}",
             response_model=DataResponse[TransferResponse],
             summary="Update transfer",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", status_code=204, summary="Delete transfer")(
-            self.delete
-        )
+        self.router.delete(
+            "/{id}",
+            status_code=204,
+            summary="Delete transfer",
+            responses=RESPONSES_DELETE,
+        )(self.delete)
         self.router.post(
             "/{id}/confirm",
             response_model=DataResponse[TransferResponse],
             summary="Confirm transfer",
+            responses=RESPONSES_COMMAND,
         )(self.confirm)
         self.router.post(
             "/{id}/receive",
             response_model=DataResponse[TransferResponse],
             summary="Receive transfer",
+            responses=RESPONSES_COMMAND,
         )(self.receive)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[TransferResponse],
             summary="Cancel transfer",
+            responses=RESPONSES_COMMAND,
         )(self.cancel)
         self.router.post(
             "/{id}/items",
             response_model=DataResponse[TransferItemResponse],
             summary="Add item to transfer",
+            responses=RESPONSES_COMMAND,
         )(self.add_item)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[TransferItemResponse],
             summary="Get transfer items",
+            responses=RESPONSES_LIST,
         )(self.get_items)
 
     def get_all(
@@ -238,10 +254,14 @@ class TransferItemRouter:
             "/{id}",
             response_model=DataResponse[TransferItemResponse],
             summary="Update transfer item",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", status_code=204, summary="Remove transfer item")(
-            self.remove
-        )
+        self.router.delete(
+            "/{id}",
+            status_code=204,
+            summary="Remove transfer item",
+            responses=RESPONSES_DELETE,
+        )(self.remove)
 
     def update(
         self,

--- a/src/inventory/transfer/infra/validators.py
+++ b/src/inventory/transfer/infra/validators.py
@@ -3,65 +3,70 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from src.inventory.transfer.domain.entities import TransferStatus
 from src.shared.infra.validators import QueryParams
 
 
 class CreateTransferRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    source_location_id: int
-    destination_location_id: int
-    notes: str | None = None
-    requested_by: str | None = None
+    source_location_id: int = Field(description="Source location ID")
+    destination_location_id: int = Field(description="Destination location ID")
+    notes: str | None = Field(None, description="Additional notes")
+    requested_by: str | None = Field(None, description="Name of the requester")
 
 
 class UpdateTransferRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    notes: str | None = None
-    requested_by: str | None = None
+    notes: str | None = Field(None, description="Updated notes")
+    requested_by: str | None = Field(None, description="Updated requester name")
 
 
 class AddTransferItemRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    product_id: int
-    quantity: int = Field(gt=0)
-    lot_id: int | None = None
-    notes: str | None = None
+    product_id: int = Field(description="Product ID to transfer")
+    quantity: int = Field(gt=0, description="Quantity to transfer")
+    lot_id: int | None = Field(None, description="Lot ID (if applicable)")
+    notes: str | None = Field(None, description="Notes for this item")
 
 
 class UpdateTransferItemRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    quantity: int | None = Field(None, gt=0)
-    notes: str | None = None
+    quantity: int | None = Field(None, gt=0, description="Updated quantity")
+    notes: str | None = Field(None, description="Updated notes")
 
 
 class TransferResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    source_location_id: int
-    destination_location_id: int
-    status: str
-    transfer_date: datetime | None = None
-    requested_by: str | None = None
-    notes: str | None = None
-    created_at: datetime | None = None
+    id: int = Field(description="Transfer ID")
+    source_location_id: int = Field(description="Source location ID")
+    destination_location_id: int = Field(description="Destination location ID")
+    status: TransferStatus = Field(description="Current transfer status")
+    transfer_date: datetime | None = Field(None, description="Date of the transfer")
+    requested_by: str | None = Field(
+        None, description="Person who requested the transfer"
+    )
+    notes: str | None = Field(None, description="Additional notes")
+    created_at: datetime | None = Field(None, description="Record creation timestamp")
 
 
 class TransferItemResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    transfer_id: int
-    product_id: int
-    quantity: int
-    lot_id: int | None = None
-    notes: str | None = None
+    id: int = Field(description="Transfer item ID")
+    transfer_id: int = Field(description="Parent transfer ID")
+    product_id: int = Field(description="Product ID")
+    quantity: int = Field(description="Quantity to transfer")
+    lot_id: int | None = Field(None, description="Lot ID (if applicable)")
+    notes: str | None = Field(None, description="Notes for this item")
 
 
 class TransferQueryParams(QueryParams):
-    status: str | None = None
-    source_location_id: int | None = Field(None, ge=1)
+    status: TransferStatus | None = Field(None, description="Filter by transfer status")
+    source_location_id: int | None = Field(
+        None, ge=1, description="Filter by source location ID"
+    )

--- a/src/inventory/warehouse/infra/routes.py
+++ b/src/inventory/warehouse/infra/routes.py
@@ -21,7 +21,15 @@ from src.inventory.warehouse.app.queries.get_warehouse import (
 )
 from src.inventory.warehouse.infra.validators import WarehouseRequest, WarehouseResponse
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, ListResponse, Meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    ListResponse,
+    Meta,
+)
 
 
 class WarehouseRouter:
@@ -34,22 +42,28 @@ class WarehouseRouter:
             "",
             response_model=DataResponse[WarehouseResponse],
             summary="Create warehouse",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[WarehouseResponse],
             summary="Update warehouse",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete warehouse")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete warehouse", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=ListResponse[WarehouseResponse],
             summary="Get all warehouses",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[WarehouseResponse],
             summary="Get warehouse by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(
@@ -58,6 +72,7 @@ class WarehouseRouter:
         handler: Injected[CreateWarehouseCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[WarehouseResponse]:
+        """Create a new warehouse facility."""
         result = handler.handle(
             CreateWarehouseCommand(**body.model_dump(by_alias=False))
         )
@@ -70,12 +85,14 @@ class WarehouseRouter:
         handler: Injected[UpdateWarehouseCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[WarehouseResponse]:
+        """Update a warehouse's name, code, address, or active status."""
         result = handler.handle(
             UpdateWarehouseCommand(warehouse_id=id, **body.model_dump(by_alias=False))
         )
         return DataResponse(data=WarehouseResponse.model_validate(result), meta=meta)
 
     def delete(self, id: int, handler: Injected[DeleteWarehouseCommandHandler]) -> None:
+        """Delete a warehouse. Fails if it contains locations with stock."""
         handler.handle(DeleteWarehouseCommand(warehouse_id=id))
 
     def get_all(
@@ -84,6 +101,7 @@ class WarehouseRouter:
         is_active: bool | None = None,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[WarehouseResponse]:
+        """List all warehouses. Optionally filter by active status."""
         result = handler.handle(GetAllWarehousesQuery(is_active=is_active))
         return ListResponse(
             data=[WarehouseResponse.model_validate(w) for w in result], meta=meta
@@ -95,5 +113,6 @@ class WarehouseRouter:
         handler: Injected[GetWarehouseByIdQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[WarehouseResponse]:
+        """Retrieve a warehouse by its ID."""
         result = handler.handle(GetWarehouseByIdQuery(warehouse_id=id))
         return DataResponse(data=WarehouseResponse.model_validate(result), meta=meta)

--- a/src/inventory/warehouse/infra/validators.py
+++ b/src/inventory/warehouse/infra/validators.py
@@ -1,33 +1,33 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
 class WarehouseRequest(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    name: str
-    code: str
-    address: str | None = None
-    city: str | None = None
-    country: str | None = None
-    is_active: bool = True
-    is_default: bool = False
-    manager: str | None = None
-    phone: str | None = None
-    email: str | None = None
+    name: str = Field(description="Warehouse name")
+    code: str = Field(description="Unique warehouse code (e.g. WH-001)")
+    address: str | None = Field(None, description="Street address")
+    city: str | None = Field(None, description="City")
+    country: str | None = Field(None, description="Country")
+    is_active: bool = Field(True, description="Whether the warehouse is active")
+    is_default: bool = Field(False, description="Whether this is the default warehouse")
+    manager: str | None = Field(None, description="Name of the warehouse manager")
+    phone: str | None = Field(None, description="Contact phone number")
+    email: str | None = Field(None, description="Contact email address")
 
 
 class WarehouseResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    name: str
-    code: str
-    address: str | None = None
-    city: str | None = None
-    country: str | None = None
-    is_active: bool
-    is_default: bool
-    manager: str | None = None
-    phone: str | None = None
-    email: str | None = None
+    id: int = Field(description="Warehouse ID")
+    name: str = Field(description="Warehouse name")
+    code: str = Field(description="Unique warehouse code")
+    address: str | None = Field(None, description="Street address")
+    city: str | None = Field(None, description="City")
+    country: str | None = Field(None, description="Country")
+    is_active: bool = Field(description="Whether the warehouse is active")
+    is_default: bool = Field(description="Whether this is the default warehouse")
+    manager: str | None = Field(None, description="Name of the warehouse manager")
+    phone: str | None = Field(None, description="Contact phone number")
+    email: str | None = Field(None, description="Contact email address")

--- a/src/pos/cash/infra/routes.py
+++ b/src/pos/cash/infra/routes.py
@@ -20,7 +20,14 @@ from src.pos.cash.infra.validators import (
     RegisterCashMovementRequest,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class POSCashRouter:
@@ -34,16 +41,19 @@ class POSCashRouter:
             response_model=DataResponse[CashMovementResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Register cash movement",
+            responses=RESPONSES_COMMAND,
         )(self.register_cash_movement)
         self.router.get(
             "/{shift_id}/cash-movements",
             response_model=PaginatedDataResponse[CashMovementResponse],
             summary="List cash movements for a shift",
+            responses=RESPONSES_LIST,
         )(self.get_cash_movements)
         self.router.get(
             "/{shift_id}/cash-summary",
             response_model=DataResponse[CashSummaryResponse],
             summary="Get cash summary for a shift",
+            responses=RESPONSES_QUERY,
         )(self.get_cash_summary)
 
     def register_cash_movement(
@@ -53,6 +63,7 @@ class POSCashRouter:
         data: RegisterCashMovementRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[CashMovementResponse]:
+        """Register a cash-in or cash-out movement for a shift (e.g. petty cash withdrawal, float top-up)."""
         result = handler.handle(
             RegisterCashMovementCommand(
                 shift_id=shift_id,
@@ -71,6 +82,7 @@ class POSCashRouter:
         query_params: CashMovementQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[CashMovementResponse]:
+        """List all cash movements recorded during a shift. Supports pagination."""
         result = handler.handle(
             GetCashMovementsQuery(
                 shift_id=shift_id,
@@ -93,5 +105,6 @@ class POSCashRouter:
         shift_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[CashSummaryResponse]:
+        """Get a summary of cash activity for a shift, including totals by payment method and net cash."""
         result = handler.handle(GetCashSummaryQuery(shift_id=shift_id))
         return DataResponse(data=CashSummaryResponse.model_validate(result), meta=meta)

--- a/src/pos/cash/infra/validators.py
+++ b/src/pos/cash/infra/validators.py
@@ -3,16 +3,20 @@ from datetime import datetime
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
+from src.pos.cash.domain.entities import CashMovementType
 from src.shared.infra.validators import DecimalNumber, QueryParams
 
 
 class RegisterCashMovementRequest(BaseModel):
-    type: str = Field(..., pattern="^(IN|OUT)$", description="IN or OUT")
-    amount: DecimalNumber = Field(..., gt=0)
-    reason: str | None = Field(None, max_length=512)
+    type: CashMovementType = Field(..., description="Cash movement direction")
+    amount: DecimalNumber = Field(..., gt=0, description="Cash amount")
+    reason: str | None = Field(
+        None, max_length=512, description="Reason for the cash movement"
+    )
     performed_by: str | None = Field(
         None,
         max_length=64,
+        description="Name of the person performing the movement",
         validation_alias=AliasChoices("performedBy", "performed_by"),
         serialization_alias="performedBy",
     )
@@ -21,13 +25,15 @@ class RegisterCashMovementRequest(BaseModel):
 class CashMovementResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    shift_id: int
-    type: str
-    amount: DecimalNumber
-    reason: str | None = None
-    performed_by: str | None = None
-    created_at: datetime | None = None
+    id: int = Field(description="Cash movement ID")
+    shift_id: int = Field(description="Shift ID this movement belongs to")
+    type: CashMovementType = Field(description="Cash movement direction")
+    amount: DecimalNumber = Field(description="Cash amount")
+    reason: str | None = Field(None, description="Reason for the movement")
+    performed_by: str | None = Field(
+        None, description="Person who performed the movement"
+    )
+    created_at: datetime | None = Field(None, description="Record creation timestamp")
 
 
 class CashMovementQueryParams(QueryParams):
@@ -37,10 +43,14 @@ class CashMovementQueryParams(QueryParams):
 class CashSummaryResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    shift_id: int
-    opening_balance: DecimalNumber
-    cash_sales: DecimalNumber
-    cash_refunds: DecimalNumber
-    cash_in: DecimalNumber
-    cash_out: DecimalNumber
-    expected_balance: DecimalNumber
+    shift_id: int = Field(description="Shift ID")
+    opening_balance: DecimalNumber = Field(
+        description="Opening balance when the shift started"
+    )
+    cash_sales: DecimalNumber = Field(description="Total cash received from sales")
+    cash_refunds: DecimalNumber = Field(description="Total cash returned in refunds")
+    cash_in: DecimalNumber = Field(description="Total manual cash-in movements")
+    cash_out: DecimalNumber = Field(description="Total manual cash-out movements")
+    expected_balance: DecimalNumber = Field(
+        description="Expected cash balance (opening + sales - refunds + in - out)"
+    )

--- a/src/pos/infra/routes.py
+++ b/src/pos/infra/routes.py
@@ -27,7 +27,14 @@ from src.customers.app.queries.customer import (
 from src.customers.infra.validators import CustomerResponse
 from src.pos.infra.validators import QuickCustomerRequest
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, ListResponse, Meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    ListResponse,
+    Meta,
+)
 
 
 class POSProductRouter:
@@ -40,16 +47,19 @@ class POSProductRouter:
             "",
             response_model=ListResponse[ProductResponse],
             summary="List products",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/search",
             response_model=ListResponse[ProductResponse],
             summary="Search products by SKU, barcode or name",
+            responses=RESPONSES_LIST,
         )(self.search)
         self.router.get(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Get product",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def get_all(
@@ -57,6 +67,7 @@ class POSProductRouter:
         handler: Injected[GetAllProductsQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[ProductResponse]:
+        """List all active products available for POS sale."""
         result = handler.handle(GetAllProductsQuery())
         return ListResponse(
             data=[ProductResponse.model_validate(p) for p in result["items"]], meta=meta
@@ -69,6 +80,7 @@ class POSProductRouter:
         limit: int = Query(20, ge=1, le=100),
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[ProductResponse]:
+        """Search products by SKU, barcode, or name fragment. Returns up to `limit` matches."""
         result = handler.handle(SearchProductsQuery(search_term=term, limit=limit))
         return ListResponse(
             data=[ProductResponse.model_validate(p) for p in result["items"]], meta=meta
@@ -80,6 +92,7 @@ class POSProductRouter:
         handler: Injected[GetProductByIdQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ProductResponse]:
+        """Retrieve a product by its ID, including pricing and tax information."""
         result = handler.handle(GetProductByIdQuery(product_id=id))
         return DataResponse(data=ProductResponse.model_validate(result), meta=meta)
 
@@ -95,21 +108,25 @@ class POSCustomerRouter:
             response_model=DataResponse[CustomerResponse],
             summary="Quick create customer",
             status_code=201,
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.get(
             "",
             response_model=ListResponse[CustomerResponse],
             summary="List customers",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/search/by-tax-id",
             response_model=DataResponse[CustomerResponse],
             summary="Search customer by tax ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_tax_id)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def create(
@@ -118,6 +135,7 @@ class POSCustomerRouter:
         handler: Injected[CreateCustomerCommandHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[CustomerResponse]:
+        """Quickly create a customer with minimal information (name + tax ID) during checkout."""
         command = CreateCustomerCommand(
             name=data.name,
             tax_id=data.tax_id,
@@ -131,6 +149,7 @@ class POSCustomerRouter:
         handler: Injected[GetAllCustomersQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[CustomerResponse]:
+        """List all customers for POS lookup."""
         result = handler.handle(GetAllCustomersQuery())
         return ListResponse(
             data=[CustomerResponse.model_validate(c) for c in result], meta=meta
@@ -142,6 +161,7 @@ class POSCustomerRouter:
         handler: Injected[GetCustomerByIdQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[CustomerResponse]:
+        """Retrieve a customer by their ID."""
         result = handler.handle(GetCustomerByIdQuery(id=id))
         return DataResponse(data=CustomerResponse.model_validate(result), meta=meta)
 
@@ -151,5 +171,6 @@ class POSCustomerRouter:
         tax_id: str = Query(..., alias="taxId", description="Tax ID to search for"),
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[CustomerResponse]:
+        """Look up a customer by their tax ID (RUC / CI)."""
         result = handler.handle(GetCustomerByTaxIdQuery(tax_id=tax_id))
         return DataResponse(data=CustomerResponse.model_validate(result), meta=meta)

--- a/src/pos/refund/infra/routes.py
+++ b/src/pos/refund/infra/routes.py
@@ -27,7 +27,14 @@ from src.pos.refund.infra.validators import (
     RefundResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class POSRefundRouter:
@@ -41,26 +48,31 @@ class POSRefundRouter:
             response_model=DataResponse[RefundDetailResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Create refund",
+            responses=RESPONSES_COMMAND,
         )(self.create_refund)
         self.router.post(
             "/{refund_id}/process",
             response_model=DataResponse[RefundDetailResponse],
             summary="Process refund",
+            responses=RESPONSES_COMMAND,
         )(self.process_refund)
         self.router.post(
             "/{refund_id}/cancel",
             response_model=DataResponse[RefundResponse],
             summary="Cancel refund",
+            responses=RESPONSES_COMMAND,
         )(self.cancel_refund)
         self.router.get(
             "/{refund_id}",
             response_model=DataResponse[RefundDetailResponse],
             summary="Get refund",
+            responses=RESPONSES_QUERY,
         )(self.get_refund)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[RefundResponse],
             summary="List refunds",
+            responses=RESPONSES_LIST,
         )(self.list_refunds)
 
     def create_refund(
@@ -69,6 +81,11 @@ class POSRefundRouter:
         refund_input: CreateRefundRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[RefundDetailResponse]:
+        """Create a refund for a confirmed sale.
+
+        Specify the items to refund (partial or total). The refund is created in PENDING
+        status and must be processed to register payments and restore inventory.
+        """
         result = handler.handle(
             CreateRefundCommand(
                 original_sale_id=refund_input.original_sale_id,
@@ -86,6 +103,11 @@ class POSRefundRouter:
         process_input: ProcessRefundRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[RefundDetailResponse]:
+        """Process a pending refund by registering refund payments.
+
+        The total of all payments must cover the refund amount. Once processed,
+        inventory IN movements are created to restore stock.
+        """
         result = handler.handle(
             ProcessRefundCommand(
                 refund_id=refund_id,
@@ -100,6 +122,7 @@ class POSRefundRouter:
         refund_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[RefundResponse]:
+        """Cancel a pending refund. Only refunds that have not been processed can be cancelled."""
         result = handler.handle(CancelRefundCommand(refund_id=refund_id))
         return DataResponse(data=RefundResponse.model_validate(result), meta=meta)
 
@@ -109,6 +132,7 @@ class POSRefundRouter:
         refund_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[RefundDetailResponse]:
+        """Retrieve a refund by ID, including its items and payments."""
         result = handler.handle(GetRefundByIdQuery(refund_id=refund_id))
         return DataResponse(data=RefundDetailResponse.model_validate(result), meta=meta)
 
@@ -118,6 +142,7 @@ class POSRefundRouter:
         meta: Meta = Depends(get_meta),
         params: RefundQueryParams = Depends(),
     ) -> PaginatedDataResponse[RefundResponse]:
+        """List refunds with optional filtering by sale ID or status. Supports pagination."""
         result = handler.handle(
             GetRefundsQuery(
                 sale_id=params.sale_id,

--- a/src/pos/refund/infra/validators.py
+++ b/src/pos/refund/infra/validators.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+from src.pos.refund.domain.entities import RefundStatus
+from src.sales.domain.entities import PaymentMethod
 from src.shared.infra.validators import DecimalNumber, QueryParams
 
 
@@ -10,52 +12,52 @@ class CreateRefundItemInput(BaseModel):
     sale_item_id: int = Field(
         ...,
         gt=0,
-        description="ID del item de venta original",
+        description="Original sale item ID to refund",
         validation_alias=AliasChoices("saleItemId", "sale_item_id"),
         serialization_alias="saleItemId",
     )
-    quantity: int = Field(..., gt=0, description="Cantidad a devolver")
+    quantity: int = Field(..., gt=0, description="Quantity to refund")
 
 
 class CreateRefundRequest(BaseModel):
     original_sale_id: int = Field(
         ...,
         gt=0,
-        description="ID de la venta original",
+        description="Original sale ID to refund against",
         validation_alias=AliasChoices("originalSaleId", "original_sale_id"),
         serialization_alias="originalSaleId",
     )
     items: list[CreateRefundItemInput] = Field(
-        ..., min_length=1, description="Items a devolver"
+        ..., min_length=1, description="Items to refund (partial or total)"
     )
     reason: str | None = Field(
-        None, max_length=512, description="Razon de la devolucion"
+        None, max_length=512, description="Reason for the refund"
     )
     refunded_by: str | None = Field(
         None,
         max_length=64,
-        description="Usuario que realiza la devolucion",
+        description="User who processed the refund",
         validation_alias=AliasChoices("refundedBy", "refunded_by"),
         serialization_alias="refundedBy",
     )
 
 
 class ProcessRefundPaymentInput(BaseModel):
-    amount: Decimal = Field(..., gt=0, description="Monto del reembolso")
-    payment_method: str = Field(
+    amount: Decimal = Field(..., gt=0, description="Refund payment amount")
+    payment_method: PaymentMethod = Field(
         ...,
-        description="Metodo de pago",
+        description="Payment method for the refund",
         validation_alias=AliasChoices("paymentMethod", "payment_method"),
         serialization_alias="paymentMethod",
     )
-    reference: str | None = Field(
-        None, max_length=128, description="Referencia del pago"
-    )
+    reference: str | None = Field(None, max_length=128, description="Payment reference")
 
 
 class ProcessRefundRequest(BaseModel):
     payments: list[ProcessRefundPaymentInput] = Field(
-        ..., min_length=1, description="Pagos del reembolso"
+        ...,
+        min_length=1,
+        description="Refund payments (total must cover the refund amount)",
     )
 
 
@@ -108,8 +110,9 @@ class RefundPaymentResponse(BaseModel):
         serialization_alias="refundId",
     )
     amount: DecimalNumber
-    payment_method: str = Field(
+    payment_method: PaymentMethod = Field(
         ...,
+        description="Payment method used for the refund",
         validation_alias=AliasChoices("paymentMethod", "payment_method"),
         serialization_alias="paymentMethod",
     )
@@ -144,7 +147,7 @@ class RefundResponse(BaseModel):
     tax: DecimalNumber
     total: DecimalNumber
     reason: str | None
-    status: str
+    status: RefundStatus = Field(description="Current refund status")
     refunded_by: str | None = Field(
         None,
         validation_alias=AliasChoices("refundedBy", "refunded_by"),
@@ -165,5 +168,5 @@ class RefundDetailResponse(RefundResponse):
 
 
 class RefundQueryParams(QueryParams):
-    sale_id: int | None = Field(None, ge=1)
-    status: str | None = None
+    sale_id: int | None = Field(None, ge=1, description="Filter by original sale ID")
+    status: RefundStatus | None = Field(None, description="Filter by refund status")

--- a/src/pos/reports/infra/routes.py
+++ b/src/pos/reports/infra/routes.py
@@ -22,7 +22,13 @@ from src.pos.reports.infra.validators import (
     ZReportResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, ListResponse, Meta
+from src.shared.infra.validators import (
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    ListResponse,
+    Meta,
+)
 
 
 class POSReportRouter:
@@ -35,21 +41,25 @@ class POSReportRouter:
             "/x-report",
             response_model=DataResponse[XReportResponse],
             summary="X-Report (shift sales summary)",
+            responses=RESPONSES_QUERY,
         )(self.x_report)
         self.router.get(
             "/z-report",
             response_model=DataResponse[ZReportResponse],
             summary="Z-Report (shift closing report)",
+            responses=RESPONSES_QUERY,
         )(self.z_report)
         self.router.get(
             "/daily",
             response_model=DataResponse[DailySummaryResponse],
             summary="Daily sales summary",
+            responses=RESPONSES_QUERY,
         )(self.daily_summary)
         self.router.get(
             "/by-payment-method",
             response_model=ListResponse[PaymentMethodSummaryResponse],
             summary="Sales by payment method",
+            responses=RESPONSES_LIST,
         )(self.by_payment_method)
 
     def x_report(
@@ -58,6 +68,7 @@ class POSReportRouter:
         query_params: XReportQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[XReportResponse]:
+        """Generate an X-Report — a mid-shift read-only sales summary. Does not close the shift."""
         result = handler.handle(GetXReportQuery(shift_id=query_params.shift_id))
         return DataResponse(data=XReportResponse.model_validate(result), meta=meta)
 
@@ -67,6 +78,7 @@ class POSReportRouter:
         query_params: ZReportQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ZReportResponse]:
+        """Generate a Z-Report — an end-of-shift closing report with sales totals, payments, and cash balance."""
         result = handler.handle(GetZReportQuery(shift_id=query_params.shift_id))
         return DataResponse(data=ZReportResponse.model_validate(result), meta=meta)
 
@@ -76,6 +88,7 @@ class POSReportRouter:
         query_params: DailySummaryQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[DailySummaryResponse]:
+        """Get an aggregated daily sales summary including totals, sale count, and average ticket."""
         result = handler.handle(GetDailySummaryQuery(date=query_params.date))
         return DataResponse(data=DailySummaryResponse.model_validate(result), meta=meta)
 
@@ -85,6 +98,7 @@ class POSReportRouter:
         query_params: ByPaymentMethodQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[PaymentMethodSummaryResponse]:
+        """Get sales totals grouped by payment method for a date range."""
         result = handler.handle(
             GetSalesByPaymentMethodQuery(
                 from_date=query_params.from_date,

--- a/src/pos/reports/infra/validators.py
+++ b/src/pos/reports/infra/validators.py
@@ -13,57 +13,63 @@ from src.shared.infra.validators import DecimalNumber
 class PaymentMethodDetail(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    payment_method: str
-    count: int
-    total: DecimalNumber
+    payment_method: str = Field(description="Payment method name")
+    count: int = Field(description="Number of transactions using this method")
+    total: DecimalNumber = Field(description="Total amount for this method")
 
 
 class ItemSoldDetail(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    product_name: str
-    sku: str
-    quantity: int
-    total: DecimalNumber
+    product_name: str = Field(description="Product name")
+    sku: str = Field(description="Product SKU")
+    quantity: int = Field(description="Total quantity sold")
+    total: DecimalNumber = Field(description="Total revenue for this product")
 
 
 class ShiftInfo(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    cashier_name: str
-    opened_at: str | None = None
-    status: str
+    id: int = Field(description="Shift ID")
+    cashier_name: str = Field(description="Cashier name")
+    opened_at: str | None = Field(
+        None, description="Shift opening timestamp (ISO 8601)"
+    )
+    status: str = Field(description="Shift status (OPEN or CLOSED)")
 
 
 class SalesSummary(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    count: int
-    subtotal: DecimalNumber
-    tax: DecimalNumber
-    discount: DecimalNumber
-    total: DecimalNumber
+    count: int = Field(description="Number of confirmed sales")
+    subtotal: DecimalNumber = Field(description="Total before tax and discounts")
+    tax: DecimalNumber = Field(description="Total tax amount")
+    discount: DecimalNumber = Field(description="Total discount amount")
+    total: DecimalNumber = Field(description="Net total (subtotal + tax - discount)")
 
 
 class RefundSummary(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    count: int
-    total: DecimalNumber
+    count: int = Field(description="Number of completed refunds")
+    total: DecimalNumber = Field(description="Total refund amount")
 
 
 class CashReconciliation(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    opening_balance: DecimalNumber
-    cash_sales: DecimalNumber
-    cash_refunds: DecimalNumber
-    cash_in: DecimalNumber
-    cash_out: DecimalNumber
-    expected_balance: DecimalNumber
-    closing_balance: DecimalNumber | None = None
-    discrepancy: DecimalNumber | None = None
+    opening_balance: DecimalNumber = Field(description="Opening balance")
+    cash_sales: DecimalNumber = Field(description="Cash received from sales")
+    cash_refunds: DecimalNumber = Field(description="Cash returned in refunds")
+    cash_in: DecimalNumber = Field(description="Manual cash-in movements")
+    cash_out: DecimalNumber = Field(description="Manual cash-out movements")
+    expected_balance: DecimalNumber = Field(description="Expected cash in drawer")
+    closing_balance: DecimalNumber | None = Field(
+        None, description="Actual closing balance counted"
+    )
+    discrepancy: DecimalNumber | None = Field(
+        None, description="Difference between expected and actual closing balance"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -72,18 +78,24 @@ class CashReconciliation(BaseModel):
 
 
 class XReportResponse(BaseModel):
+    """Mid-shift sales summary (non-closing). Useful for cashier progress checks."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    shift: ShiftInfo
-    sales_summary: SalesSummary
-    payments_by_method: list[PaymentMethodDetail]
-    items_sold: list[ItemSoldDetail]
+    shift: ShiftInfo = Field(description="Shift information")
+    sales_summary: SalesSummary = Field(description="Sales totals for the shift")
+    payments_by_method: list[PaymentMethodDetail] = Field(
+        description="Breakdown by payment method"
+    )
+    items_sold: list[ItemSoldDetail] = Field(
+        description="Top products sold during the shift"
+    )
 
 
 class XReportQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    shift_id: int = Field(..., ge=1)
+    shift_id: int = Field(..., ge=1, description="Shift ID to generate the report for")
 
 
 # ---------------------------------------------------------------------------
@@ -92,20 +104,28 @@ class XReportQueryParams(BaseModel):
 
 
 class ZReportResponse(BaseModel):
+    """End-of-shift closing report. Includes cash reconciliation and refund data."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    shift: ShiftInfo
-    sales_summary: SalesSummary
-    payments_by_method: list[PaymentMethodDetail]
-    items_sold: list[ItemSoldDetail]
-    refund_summary: RefundSummary
-    cash_reconciliation: CashReconciliation
+    shift: ShiftInfo = Field(description="Shift information")
+    sales_summary: SalesSummary = Field(description="Sales totals for the shift")
+    payments_by_method: list[PaymentMethodDetail] = Field(
+        description="Breakdown by payment method"
+    )
+    items_sold: list[ItemSoldDetail] = Field(
+        description="Products sold during the shift"
+    )
+    refund_summary: RefundSummary = Field(description="Refund totals for the shift")
+    cash_reconciliation: CashReconciliation = Field(
+        description="Cash drawer reconciliation"
+    )
 
 
 class ZReportQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    shift_id: int = Field(..., ge=1)
+    shift_id: int = Field(..., ge=1, description="Shift ID to generate the report for")
 
 
 # ---------------------------------------------------------------------------
@@ -114,20 +134,27 @@ class ZReportQueryParams(BaseModel):
 
 
 class DailySummaryResponse(BaseModel):
+    """Daily sales overview across all shifts."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    date: str
-    total_sales: int
-    total_amount: DecimalNumber
-    payments_by_method: list[PaymentMethodDetail]
-    top_products: list[ItemSoldDetail]
-    refund_summary: RefundSummary
+    date: str = Field(description="Report date (YYYY-MM-DD)")
+    total_sales: int = Field(description="Number of confirmed sales")
+    total_amount: DecimalNumber = Field(description="Total sales amount")
+    payments_by_method: list[PaymentMethodDetail] = Field(
+        description="Breakdown by payment method"
+    )
+    top_products: list[ItemSoldDetail] = Field(description="Top selling products")
+    refund_summary: RefundSummary = Field(description="Refund totals for the day")
 
 
 class DailySummaryQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    date: dt.date = Field(default_factory=dt.date.today)
+    date: dt.date = Field(
+        default_factory=dt.date.today,
+        description="Date for the report (defaults to today)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -136,15 +163,19 @@ class DailySummaryQueryParams(BaseModel):
 
 
 class PaymentMethodSummaryResponse(BaseModel):
+    """Sales totals grouped by payment method."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    payment_method: str
-    sales_count: int
-    total_amount: DecimalNumber
+    payment_method: str = Field(description="Payment method name")
+    sales_count: int = Field(description="Number of sales using this method")
+    total_amount: DecimalNumber = Field(
+        description="Total amount collected via this method"
+    )
 
 
 class ByPaymentMethodQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    from_date: dt.date | None = None
-    to_date: dt.date | None = None
+    from_date: dt.date | None = Field(None, description="Start date (inclusive)")
+    to_date: dt.date | None = Field(None, description="End date (inclusive)")

--- a/src/pos/sales/infra/routes.py
+++ b/src/pos/sales/infra/routes.py
@@ -87,7 +87,15 @@ from src.sales.infra.validators import (
     SaleResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, ListResponse, Meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    ListResponse,
+    Meta,
+)
 
 
 class POSSaleRouter:
@@ -101,87 +109,105 @@ class POSSaleRouter:
             response_model=DataResponse[SaleResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Create sale",
+            responses=RESPONSES_COMMAND,
         )(self.create_sale)
         self.router.post(
             "/quick",
             response_model=DataResponse[SaleDetailResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Quick sale (checkout in one request)",
+            responses=RESPONSES_COMMAND,
         )(self.quick_sale)
         self.router.get(
             "/parked",
             response_model=ListResponse[SaleResponse],
             summary="List parked sales",
+            responses=RESPONSES_LIST,
         )(self.get_parked_sales)
         self.router.get(
             "/{sale_id}",
             response_model=DataResponse[SaleResponse],
             summary="Get sale",
+            responses=RESPONSES_QUERY,
         )(self.get_sale)
         self.router.post(
             "/{sale_id}/items",
             response_model=DataResponse[SaleItemResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Add item to sale",
+            responses=RESPONSES_COMMAND,
         )(self.add_sale_item)
         self.router.get(
             "/{sale_id}/items",
             response_model=ListResponse[SaleItemResponse],
             summary="List sale items",
+            responses=RESPONSES_LIST,
         )(self.get_sale_items)
         self.router.put(
             "/{sale_id}/items/{item_id}",
             response_model=DataResponse[SaleItemResponse],
             summary="Update sale item",
+            responses=RESPONSES_COMMAND,
         )(self.update_sale_item)
         self.router.delete(
-            "/{sale_id}/items/{item_id}", summary="Remove item from sale"
+            "/{sale_id}/items/{item_id}",
+            summary="Remove item from sale",
+            responses=RESPONSES_DELETE,
         )(self.remove_sale_item)
         self.router.post(
             "/{sale_id}/confirm",
             response_model=DataResponse[SaleResponse],
             summary="Confirm sale",
+            responses=RESPONSES_COMMAND,
         )(self.confirm_sale)
         self.router.post(
             "/{sale_id}/cancel",
             response_model=DataResponse[SaleResponse],
             summary="Cancel sale",
+            responses=RESPONSES_COMMAND,
         )(self.cancel_sale)
         self.router.post(
             "/{sale_id}/park",
             response_model=DataResponse[SaleResponse],
             summary="Park sale",
+            responses=RESPONSES_COMMAND,
         )(self.park_sale)
         self.router.post(
             "/{sale_id}/resume",
             response_model=DataResponse[SaleResponse],
             summary="Resume parked sale",
+            responses=RESPONSES_COMMAND,
         )(self.resume_sale)
         self.router.post(
             "/{sale_id}/discount",
             response_model=DataResponse[SaleResponse],
             summary="Apply discount to sale",
+            responses=RESPONSES_COMMAND,
         )(self.apply_discount)
         self.router.post(
             "/{sale_id}/payments",
             response_model=DataResponse[PaymentResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Register payment",
+            responses=RESPONSES_COMMAND,
         )(self.register_payment)
         self.router.get(
             "/{sale_id}/payments",
             response_model=ListResponse[PaymentResponse],
             summary="List sale payments",
+            responses=RESPONSES_LIST,
         )(self.get_sale_payments)
         self.router.put(
             "/{sale_id}/items/{item_id}/price",
             response_model=DataResponse[SaleItemResponse],
             summary="Override item price",
+            responses=RESPONSES_COMMAND,
         )(self.override_item_price)
         self.router.get(
             "/{sale_id}/receipt",
             response_model=DataResponse[ReceiptResponse],
             summary="Generate receipt",
+            responses=RESPONSES_QUERY,
         )(self.generate_receipt)
 
     def create_sale(
@@ -190,6 +216,11 @@ class POSSaleRouter:
         sale: POSSaleRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Create a new POS sale in DRAFT status.
+
+        The sale must have items added and payments registered before it can be confirmed.
+        Optionally associate a customer or mark it as a final-consumer sale.
+        """
         result = handler.handle(
             POSCreateSaleCommand(**sale.model_dump(exclude_none=True))
         )
@@ -201,6 +232,11 @@ class POSSaleRouter:
         sale: QuickSaleRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleDetailResponse]:
+        """Complete a sale in a single request — creates the sale, adds items, registers payments, and confirms.
+
+        This is the fastest checkout flow: supply line items and payments, and the sale
+        is created and confirmed atomically. Inventory movements are generated immediately.
+        """
         result = handler.handle(
             QuickSaleCommand(
                 items=[item.model_dump() for item in sale.items],
@@ -218,6 +254,7 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Retrieve a sale by its ID, including current status and totals."""
         result = handler.handle(GetSaleByIdQuery(sale_id=sale_id))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
 
@@ -228,6 +265,7 @@ class POSSaleRouter:
         item: SaleItemRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleItemResponse]:
+        """Add a line item to a DRAFT sale. The sale totals are recalculated automatically."""
         result = handler.handle(
             AddSaleItemCommand(sale_id=sale_id, **item.model_dump(exclude_none=True))
         )
@@ -239,6 +277,7 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[SaleItemResponse]:
+        """List all line items for a sale."""
         result = handler.handle(GetSaleItemsQuery(sale_id=sale_id))
         return ListResponse(
             data=[SaleItemResponse.model_validate(r) for r in result], meta=meta
@@ -252,6 +291,7 @@ class POSSaleRouter:
         item: SaleItemUpdateRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleItemResponse]:
+        """Update quantity or discount of a line item in a DRAFT sale."""
         result = handler.handle(
             UpdateSaleItemCommand(
                 sale_id=sale_id,
@@ -267,6 +307,7 @@ class POSSaleRouter:
         sale_id: int,
         item_id: int,
     ) -> dict:
+        """Remove a line item from a DRAFT sale."""
         return handler.handle(
             RemoveSaleItemCommand(sale_id=sale_id, sale_item_id=item_id)
         )
@@ -277,6 +318,11 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Confirm a sale and trigger inventory movements.
+
+        The sale must have at least one item and payments covering the total amount.
+        Once confirmed, inventory OUT movements are created for each line item.
+        """
         result = handler.handle(POSConfirmSaleCommand(sale_id=sale_id))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
 
@@ -287,6 +333,7 @@ class POSSaleRouter:
         cancel_input: CancelSaleRequest | None = None,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Cancel a sale. If the sale was confirmed, inventory movements are reversed."""
         reason = cancel_input.reason if cancel_input else None
         result = handler.handle(POSCancelSaleCommand(sale_id=sale_id, reason=reason))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
@@ -298,6 +345,10 @@ class POSSaleRouter:
         discount_input: ApplyDiscountRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Apply a percentage or fixed-amount discount to a DRAFT sale.
+
+        The discount is applied to the sale subtotal before tax calculation.
+        """
         result = handler.handle(
             ApplySaleDiscountCommand(sale_id=sale_id, **discount_input.model_dump())
         )
@@ -310,6 +361,7 @@ class POSSaleRouter:
         payment: PaymentRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[PaymentResponse]:
+        """Register a payment against a sale. Multiple payments with different methods are supported."""
         result = handler.handle(
             RegisterPaymentCommand(
                 sale_id=sale_id, **payment.model_dump(exclude_none=True)
@@ -323,6 +375,7 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[PaymentResponse]:
+        """List all payments registered for a sale."""
         result = handler.handle(GetSalePaymentsQuery(sale_id=sale_id))
         return ListResponse(
             data=[PaymentResponse.model_validate(r) for r in result], meta=meta
@@ -335,6 +388,7 @@ class POSSaleRouter:
         park_input: ParkSaleRequest | None = None,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Park (hold) a DRAFT sale for later. Parked sales appear in the parked-sales list."""
         reason = park_input.reason if park_input else None
         result = handler.handle(ParkSaleCommand(sale_id=sale_id, reason=reason))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
@@ -345,6 +399,7 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Resume a previously parked sale, returning it to DRAFT status."""
         result = handler.handle(ResumeSaleCommand(sale_id=sale_id))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
 
@@ -353,6 +408,7 @@ class POSSaleRouter:
         handler: Injected[GetParkedSalesQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[SaleResponse]:
+        """List all currently parked sales awaiting resumption."""
         result = handler.handle(GetParkedSalesQuery())
         return ListResponse(
             data=[SaleResponse.model_validate(r) for r in result], meta=meta
@@ -366,6 +422,7 @@ class POSSaleRouter:
         body: OverridePriceRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleItemResponse]:
+        """Override the unit price of a sale item. A reason is required for audit purposes."""
         result = handler.handle(
             OverrideItemPriceCommand(
                 sale_id=sale_id,
@@ -382,5 +439,6 @@ class POSSaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ReceiptResponse]:
+        """Generate a printable receipt for a confirmed sale, including items, tax breakdown, and payments."""
         result = handler.handle(GenerateReceiptQuery(sale_id=sale_id))
         return DataResponse(data=ReceiptResponse.model_validate(result), meta=meta)

--- a/src/pos/sales/infra/validators.py
+++ b/src/pos/sales/infra/validators.py
@@ -1,41 +1,43 @@
-"""Pydantic schemas para validacion POS Sales"""
+"""Pydantic schemas for POS Sales validation and serialization."""
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+from src.sales.domain.entities import PaymentMethod, SaleStatus
 from src.shared.infra.validators import DecimalNumber
 
 
 class ParkSaleRequest(BaseModel):
-    """Schema para aparcar una venta"""
+    """Park (hold) a sale for later."""
 
     reason: str | None = Field(
-        None, max_length=512, description="Razon para aparcar la venta"
+        None, max_length=512, description="Reason for parking the sale"
     )
 
 
 class ApplyDiscountRequest(BaseModel):
-    """Schema para aplicar descuento a una venta"""
+    """Apply a discount to an entire sale."""
 
-    discount_type: str = Field(
+    discount_type: Literal["PERCENTAGE", "AMOUNT"] = Field(
         ...,
-        description="Tipo de descuento: PERCENTAGE o AMOUNT",
+        description="Discount type: PERCENTAGE (percentage off) or AMOUNT (fixed amount off)",
         validation_alias=AliasChoices("discountType", "discount_type"),
         serialization_alias="discountType",
     )
     discount_value: Decimal = Field(
         ...,
         ge=0,
-        description="Valor del descuento",
+        description="Discount value (percentage or fixed amount depending on discountType)",
         validation_alias=AliasChoices("discountValue", "discount_value"),
         serialization_alias="discountValue",
     )
 
 
 class OverridePriceRequest(BaseModel):
-    """Schema para sobreescribir el precio de un item"""
+    """Override the price of a sale item (requires a reason)."""
 
     new_price: Decimal = Field(
         ...,
@@ -47,97 +49,95 @@ class OverridePriceRequest(BaseModel):
 
 
 class POSSaleRequest(BaseModel):
-    """Schema para crear una venta desde POS"""
+    """Create a new POS sale in DRAFT status."""
 
     customer_id: int | None = Field(
         None,
         gt=0,
-        description="ID del cliente (opcional si es consumidor final)",
+        description="Customer ID (optional for final consumers)",
         validation_alias=AliasChoices("customerId", "customer_id"),
         serialization_alias="customerId",
     )
     is_final_consumer: bool = Field(
         False,
-        description="Indica si es consumidor final",
+        description="Whether this is a final consumer (anonymous) sale",
         validation_alias=AliasChoices("isFinalConsumer", "is_final_consumer"),
         serialization_alias="isFinalConsumer",
     )
-    notes: str | None = Field(None, max_length=512, description="Notas adicionales")
+    notes: str | None = Field(None, max_length=512, description="Additional notes")
     created_by: str | None = Field(
         None,
         max_length=64,
-        description="Usuario que crea",
+        description="User who created the sale",
         validation_alias=AliasChoices("createdBy", "created_by"),
         serialization_alias="createdBy",
     )
 
 
 class QuickSaleItemInput(BaseModel):
-    """Schema para un item de venta rapida"""
+    """Line item for a quick sale."""
 
     product_id: int = Field(
         ...,
         gt=0,
-        description="ID del producto",
+        description="Product ID",
         validation_alias=AliasChoices("productId", "product_id"),
         serialization_alias="productId",
     )
-    quantity: int = Field(..., gt=0, description="Cantidad")
+    quantity: int = Field(..., gt=0, description="Quantity to sell")
     unit_price: Decimal | None = Field(
         None,
         gt=0,
-        description="Precio unitario (si no se envia, usa el precio del producto)",
+        description="Unit price override (uses product sale price if omitted)",
         validation_alias=AliasChoices("unitPrice", "unit_price"),
         serialization_alias="unitPrice",
     )
     discount: Decimal = Field(
-        Decimal("0"), ge=0, le=100, description="Porcentaje de descuento"
+        Decimal("0"), ge=0, le=100, description="Discount percentage (0-100)"
     )
 
 
 class QuickSalePaymentInput(BaseModel):
-    """Schema para un pago de venta rapida"""
+    """Payment for a quick sale."""
 
-    amount: Decimal = Field(..., gt=0, description="Monto del pago")
-    payment_method: str = Field(
+    amount: Decimal = Field(..., gt=0, description="Payment amount")
+    payment_method: PaymentMethod = Field(
         ...,
-        description="Metodo de pago",
+        description="Payment method",
         validation_alias=AliasChoices("paymentMethod", "payment_method"),
         serialization_alias="paymentMethod",
     )
-    reference: str | None = Field(
-        None, max_length=128, description="Referencia del pago"
-    )
+    reference: str | None = Field(None, max_length=128, description="Payment reference")
 
 
 class QuickSaleRequest(BaseModel):
-    """Schema para venta rapida (checkout completo en un request)"""
+    """Complete checkout in a single request — creates sale, adds items, registers payments, and confirms."""
 
     customer_id: int | None = Field(
         None,
         gt=0,
-        description="ID del cliente (si no se envia, es consumidor final)",
+        description="Customer ID (final consumer if omitted)",
         validation_alias=AliasChoices("customerId", "customer_id"),
         serialization_alias="customerId",
     )
     items: list[QuickSaleItemInput] = Field(
-        ..., min_length=1, description="Items de la venta"
+        ..., min_length=1, description="Line items for the sale"
     )
     payments: list[QuickSalePaymentInput] = Field(
-        ..., min_length=1, description="Pagos de la venta"
+        ..., min_length=1, description="Payments (total must cover the sale amount)"
     )
-    notes: str | None = Field(None, max_length=512, description="Notas adicionales")
+    notes: str | None = Field(None, max_length=512, description="Additional notes")
     created_by: str | None = Field(
         None,
         max_length=64,
-        description="Usuario que crea",
+        description="User who created the sale",
         validation_alias=AliasChoices("createdBy", "created_by"),
         serialization_alias="createdBy",
     )
 
 
 class ReceiptItemResponse(BaseModel):
-    """Schema para un item del recibo"""
+    """Line item in a receipt."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -182,7 +182,7 @@ class ReceiptItemResponse(BaseModel):
 
 
 class TaxBreakdownResponse(BaseModel):
-    """Schema para desglose de impuestos"""
+    """Tax breakdown by rate."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -204,7 +204,7 @@ class TaxBreakdownResponse(BaseModel):
 
 
 class ReceiptPaymentResponse(BaseModel):
-    """Schema para un pago del recibo"""
+    """Payment entry in a receipt."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -214,7 +214,7 @@ class ReceiptPaymentResponse(BaseModel):
 
 
 class CustomerReceiptResponse(BaseModel):
-    """Schema para datos del cliente en el recibo"""
+    """Customer info on a receipt."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -228,7 +228,7 @@ class CustomerReceiptResponse(BaseModel):
 
 
 class ReceiptResponse(BaseModel):
-    """Schema para respuesta del recibo completo"""
+    """Full receipt for a confirmed sale, including items, tax breakdown, and payments."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -242,7 +242,7 @@ class ReceiptResponse(BaseModel):
         validation_alias=AliasChoices("saleDate", "sale_date"),
         serialization_alias="saleDate",
     )
-    status: str
+    status: SaleStatus = Field(description="Current sale status")
     cashier: str | None = None
     customer: CustomerReceiptResponse | None = None
     is_final_consumer: bool = Field(
@@ -258,8 +258,9 @@ class ReceiptResponse(BaseModel):
     )
     subtotal: DecimalNumber
     discount: DecimalNumber
-    discount_type: str | None = Field(
+    discount_type: Literal["PERCENTAGE", "AMOUNT"] | None = Field(
         None,
+        description="Discount type applied to the sale",
         validation_alias=AliasChoices("discountType", "discount_type"),
         serialization_alias="discountType",
     )

--- a/src/pos/shift/infra/routes.py
+++ b/src/pos/shift/infra/routes.py
@@ -26,7 +26,14 @@ from src.pos.shift.infra.validators import (
     ShiftResponse,
 )
 from src.shared.infra.dependencies import get_meta
-from src.shared.infra.validators import DataResponse, Meta, PaginatedDataResponse
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
 
 
 class POSShiftRouter:
@@ -40,26 +47,31 @@ class POSShiftRouter:
             response_model=DataResponse[ShiftResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Open shift",
+            responses=RESPONSES_COMMAND,
         )(self.open_shift)
         self.router.post(
             "/{shift_id}/close",
             response_model=DataResponse[ShiftResponse],
             summary="Close shift",
+            responses=RESPONSES_COMMAND,
         )(self.close_shift)
         self.router.get(
             "/active",
             response_model=DataResponse[ShiftResponse | None],
             summary="Get active shift",
+            responses=RESPONSES_QUERY,
         )(self.get_active_shift)
         self.router.get(
             "/{shift_id}",
             response_model=DataResponse[ShiftResponse],
             summary="Get shift by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_shift)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[ShiftResponse],
             summary="List all shifts",
+            responses=RESPONSES_LIST,
         )(self.get_all_shifts)
 
     def open_shift(
@@ -68,6 +80,7 @@ class POSShiftRouter:
         data: OpenShiftRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ShiftResponse]:
+        """Open a new cashier shift. Only one shift can be active at a time."""
         result = handler.handle(
             OpenShiftCommand(
                 cashier_name=data.cashier_name,
@@ -84,6 +97,10 @@ class POSShiftRouter:
         data: CloseShiftRequest,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ShiftResponse]:
+        """Close an open shift by recording the actual closing cash balance.
+
+        The system calculates the expected balance and the discrepancy automatically.
+        """
         result = handler.handle(
             CloseShiftCommand(
                 shift_id=shift_id,
@@ -98,6 +115,7 @@ class POSShiftRouter:
         handler: Injected[GetActiveShiftQueryHandler],
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ShiftResponse | None]:
+        """Get the currently active (open) shift, or null if no shift is open."""
         result = handler.handle(GetActiveShiftQuery())
         data = ShiftResponse.model_validate(result) if result is not None else None
         return DataResponse(data=data, meta=meta)
@@ -108,6 +126,7 @@ class POSShiftRouter:
         shift_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[ShiftResponse]:
+        """Retrieve a shift by its ID."""
         result = handler.handle(GetShiftByIdQuery(shift_id=shift_id))
         return DataResponse(data=ShiftResponse.model_validate(result), meta=meta)
 
@@ -117,6 +136,7 @@ class POSShiftRouter:
         query_params: ShiftQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[ShiftResponse]:
+        """List all shifts with optional filtering by status. Supports pagination."""
         result = handler.handle(
             GetAllShiftsQuery(**query_params.model_dump(exclude_none=True))
         )

--- a/src/pos/shift/infra/validators.py
+++ b/src/pos/shift/infra/validators.py
@@ -1,48 +1,49 @@
-"""Pydantic schemas para validacion y serializacion de Shifts"""
+"""Pydantic schemas for Shift validation and serialization."""
 
 from datetime import datetime
 from decimal import Decimal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+from src.pos.shift.domain.entities import ShiftStatus
 from src.shared.infra.validators import DecimalNumber, QueryParams
 
 
 class OpenShiftRequest(BaseModel):
-    """Schema para abrir un turno"""
+    """Open a new cashier shift."""
 
     cashier_name: str = Field(
         ...,
         max_length=128,
-        description="Nombre del cajero",
+        description="Cashier name",
         validation_alias=AliasChoices("cashierName", "cashier_name"),
         serialization_alias="cashierName",
     )
     opening_balance: Decimal = Field(
         ...,
         ge=0,
-        description="Balance de apertura",
+        description="Opening cash balance",
         validation_alias=AliasChoices("openingBalance", "opening_balance"),
         serialization_alias="openingBalance",
     )
-    notes: str | None = Field(None, max_length=512, description="Notas adicionales")
+    notes: str | None = Field(None, max_length=512, description="Additional notes")
 
 
 class CloseShiftRequest(BaseModel):
-    """Schema para cerrar un turno"""
+    """Close the current shift."""
 
     closing_balance: Decimal = Field(
         ...,
         ge=0,
-        description="Balance de cierre",
+        description="Actual closing cash balance (counted)",
         validation_alias=AliasChoices("closingBalance", "closing_balance"),
         serialization_alias="closingBalance",
     )
-    notes: str | None = Field(None, max_length=512, description="Notas adicionales")
+    notes: str | None = Field(None, max_length=512, description="Additional notes")
 
 
 class ShiftResponse(BaseModel):
-    """Schema para respuesta de un turno"""
+    """Shift details."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -81,9 +82,9 @@ class ShiftResponse(BaseModel):
         None,
         validation_alias=AliasChoices("discrepancy"),
     )
-    status: str
+    status: ShiftStatus = Field(description="Current shift status")
     notes: str | None = None
 
 
 class ShiftQueryParams(QueryParams):
-    status: str | None = None
+    status: ShiftStatus | None = Field(None, description="Filter by shift status")

--- a/src/purchasing/infra/routes.py
+++ b/src/purchasing/infra/routes.py
@@ -52,6 +52,10 @@ from src.purchasing.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -69,47 +73,58 @@ class PurchaseOrderRouter:
             "",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Create purchase order",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Update purchase order",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete purchase order")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete purchase order", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[PurchaseOrderResponse],
             summary="Get all purchase orders",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Get purchase order by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.post(
             "/{id}/send",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Send purchase order to supplier",
+            responses=RESPONSES_COMMAND,
         )(self.send)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Cancel purchase order",
+            responses=RESPONSES_COMMAND,
         )(self.cancel)
         self.router.post(
             "/{id}/receive",
             response_model=DataResponse[PurchaseReceiptResponse],
             summary="Receive goods for purchase order",
+            responses=RESPONSES_COMMAND,
         )(self.receive)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[PurchaseOrderItemResponse],
             summary="Get items for a purchase order",
+            responses=RESPONSES_LIST,
         )(self.get_items)
         self.router.get(
             "/{id}/receipts",
             response_model=ListResponse[PurchaseReceiptResponse],
             summary="Get receipts for a purchase order",
+            responses=RESPONSES_LIST,
         )(self.get_receipts)
 
     def create(
@@ -271,13 +286,17 @@ class POItemRouter:
             "",
             response_model=DataResponse[PurchaseOrderItemResponse],
             summary="Add item to purchase order",
+            responses=RESPONSES_COMMAND,
         )(self.add)
         self.router.put(
             "/{id}",
             response_model=DataResponse[PurchaseOrderItemResponse],
             summary="Update purchase order item",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Remove purchase order item")(self.remove)
+        self.router.delete(
+            "/{id}", summary="Remove purchase order item", responses=RESPONSES_DELETE
+        )(self.remove)
 
     def add(
         self,

--- a/src/purchasing/infra/validators.py
+++ b/src/purchasing/infra/validators.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from pydantic import AliasChoices, BaseModel, Field
 
+from src.purchasing.domain.entities import PurchaseOrderStatus
 from src.shared.infra.validators import DecimalNumber, QueryParams
 
 
@@ -35,7 +36,7 @@ class PurchaseOrderResponse(BaseModel):
         validation_alias=AliasChoices("orderNumber", "order_number"),
         serialization_alias="orderNumber",
     )
-    status: str
+    status: PurchaseOrderStatus = Field(description="Current purchase order status")
     subtotal: DecimalNumber
     tax: DecimalNumber
     total: DecimalNumber
@@ -205,5 +206,7 @@ class PurchaseReceiptResponse(BaseModel):
 
 # Query Params
 class PurchaseOrderQueryParams(QueryParams):
-    status: str | None = None
+    status: PurchaseOrderStatus | None = Field(
+        None, description="Filter by order status"
+    )
     supplier_id: int | None = Field(None, ge=1)

--- a/src/reports/inventory/infra/routes.py
+++ b/src/reports/inventory/infra/routes.py
@@ -29,6 +29,8 @@ from src.reports.inventory.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -46,21 +48,25 @@ class ReportRouter:
             "/valuation",
             response_model=DataResponse[InventoryValuationResponse],
             summary="Inventory valuation report",
+            responses=RESPONSES_QUERY,
         )(self.valuation)
         self.router.get(
             "/rotation",
             response_model=ListResponse[ProductRotationResponse],
             summary="Product rotation report",
+            responses=RESPONSES_LIST,
         )(self.rotation)
         self.router.get(
             "/movements",
             response_model=PaginatedDataResponse[MovementHistoryItemResponse],
             summary="Movement history report",
+            responses=RESPONSES_LIST,
         )(self.movement_history)
         self.router.get(
             "/summary",
             response_model=ListResponse[WarehouseSummaryResponse],
             summary="Warehouse summary report",
+            responses=RESPONSES_LIST,
         )(self.warehouse_summary)
 
     def valuation(

--- a/src/reports/inventory/infra/validators.py
+++ b/src/reports/inventory/infra/validators.py
@@ -13,27 +13,33 @@ from src.shared.infra.validators import DecimalNumber, QueryParams
 class ValuationItemResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    product_id: int
-    product_name: str
-    sku: str
-    quantity: int
-    average_cost: DecimalNumber
-    total_value: DecimalNumber
+    product_id: int = Field(description="Product ID")
+    product_name: str = Field(description="Product name")
+    sku: str = Field(description="Product SKU")
+    quantity: int = Field(description="Current stock quantity")
+    average_cost: DecimalNumber = Field(description="Weighted average cost per unit")
+    total_value: DecimalNumber = Field(
+        description="Total inventory value (quantity x average cost)"
+    )
 
 
 class InventoryValuationResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    total_value: DecimalNumber
-    as_of_date: date
-    items: list[ValuationItemResponse]
+    total_value: DecimalNumber = Field(description="Grand total inventory value")
+    as_of_date: date = Field(description="Valuation date")
+    items: list[ValuationItemResponse] = Field(
+        description="Per-product valuation breakdown"
+    )
 
 
 class ValuationQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int | None = Field(None, ge=1)
-    as_of_date: date | None = None
+    warehouse_id: int | None = Field(None, ge=1, description="Filter by warehouse ID")
+    as_of_date: date | None = Field(
+        None, description="Valuation date (defaults to today)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -44,22 +50,31 @@ class ValuationQueryParams(BaseModel):
 class ProductRotationResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    product_id: int
-    product_name: str
-    sku: str
-    total_in: int
-    total_out: int
-    current_stock: int
-    turnover_rate: DecimalNumber
-    days_of_stock: int | None = None
+    product_id: int = Field(description="Product ID")
+    product_name: str = Field(description="Product name")
+    sku: str = Field(description="Product SKU")
+    total_in: int = Field(description="Total units received in the period")
+    total_out: int = Field(description="Total units sold/consumed in the period")
+    current_stock: int = Field(description="Current stock quantity")
+    turnover_rate: DecimalNumber = Field(
+        description="Inventory turnover rate for the period"
+    )
+    days_of_stock: int | None = Field(
+        None, description="Estimated days of stock remaining"
+    )
 
 
 class RotationQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    from_date: date = Field(default_factory=lambda: date.today().replace(day=1))
-    to_date: date = Field(default_factory=date.today)
-    warehouse_id: int | None = Field(None, ge=1)
+    from_date: date = Field(
+        default_factory=lambda: date.today().replace(day=1),
+        description="Start date (defaults to first day of current month)",
+    )
+    to_date: date = Field(
+        default_factory=date.today, description="End date (defaults to today)"
+    )
+    warehouse_id: int | None = Field(None, ge=1, description="Filter by warehouse ID")
 
 
 # ---------------------------------------------------------------------------
@@ -70,28 +85,36 @@ class RotationQueryParams(BaseModel):
 class MovementHistoryItemResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    id: int
-    product_id: int
-    product_name: str
-    sku: str
-    quantity: int
-    type: str
-    location_id: int | None = None
-    source_location_id: int | None = None
-    reference_type: str | None = None
-    reference_id: int | None = None
-    reason: str | None = None
-    date: datetime | None = None
-    created_at: datetime | None = None
+    id: int = Field(description="Movement ID")
+    product_id: int = Field(description="Product ID")
+    product_name: str = Field(description="Product name")
+    sku: str = Field(description="Product SKU")
+    quantity: int = Field(
+        description="Movement quantity (positive = IN, negative = OUT)"
+    )
+    type: str = Field(description="Movement type (IN or OUT)")
+    location_id: int | None = Field(None, description="Storage location ID")
+    source_location_id: int | None = Field(
+        None, description="Source location for transfers"
+    )
+    reference_type: str | None = Field(
+        None, description="Source entity type (e.g. sale, purchase_order)"
+    )
+    reference_id: int | None = Field(None, description="Source entity ID")
+    reason: str | None = Field(None, description="Reason for the movement")
+    date: datetime | None = Field(None, description="Movement date")
+    created_at: datetime | None = Field(None, description="Record creation timestamp")
 
 
 class MovementHistoryQueryParams(QueryParams):
-    limit: int | None = Field(50, ge=1, le=500)
-    product_id: int | None = Field(None, ge=1)
-    type: str | None = None
-    from_date: date | None = None
-    to_date: date | None = None
-    warehouse_id: int | None = Field(None, ge=1)
+    limit: int | None = Field(
+        50, ge=1, le=500, description="Maximum records to return (1-500)"
+    )
+    product_id: int | None = Field(None, ge=1, description="Filter by product ID")
+    type: str | None = Field(None, description="Filter by movement type (IN or OUT)")
+    from_date: date | None = Field(None, description="Start date (inclusive)")
+    to_date: date | None = Field(None, description="End date (inclusive)")
+    warehouse_id: int | None = Field(None, ge=1, description="Filter by warehouse ID")
 
 
 # ---------------------------------------------------------------------------
@@ -102,17 +125,19 @@ class MovementHistoryQueryParams(QueryParams):
 class WarehouseSummaryResponse(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int
-    warehouse_name: str
-    warehouse_code: str
-    total_products: int
-    total_quantity: int
-    reserved_quantity: int
-    available_quantity: int
-    total_value: DecimalNumber
+    warehouse_id: int = Field(description="Warehouse ID")
+    warehouse_name: str = Field(description="Warehouse name")
+    warehouse_code: str = Field(description="Warehouse code")
+    total_products: int = Field(description="Number of distinct products stored")
+    total_quantity: int = Field(description="Total stock quantity across all products")
+    reserved_quantity: int = Field(description="Total reserved quantity")
+    available_quantity: int = Field(description="Available quantity (total - reserved)")
+    total_value: DecimalNumber = Field(description="Total inventory value")
 
 
 class SummaryQueryParams(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    warehouse_id: int | None = Field(None, ge=1)
+    warehouse_id: int | None = Field(
+        None, ge=1, description="Filter by warehouse ID (omit for all warehouses)"
+    )

--- a/src/sales/infra/routes.py
+++ b/src/sales/infra/routes.py
@@ -25,6 +25,8 @@ from src.sales.infra.validators import (
 )
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -42,21 +44,25 @@ class SaleRouter:
             "",
             response_model=PaginatedDataResponse[SaleResponse],
             summary="List all sales",
+            responses=RESPONSES_LIST,
         )(self.get_all_sales)
         self.router.get(
             "/{sale_id}",
             response_model=DataResponse[SaleResponse],
             summary="Get sale",
+            responses=RESPONSES_QUERY,
         )(self.get_sale)
         self.router.get(
             "/{sale_id}/items",
             response_model=ListResponse[SaleItemResponse],
             summary="List sale items",
+            responses=RESPONSES_LIST,
         )(self.get_sale_items)
         self.router.get(
             "/{sale_id}/payments",
             response_model=ListResponse[PaymentResponse],
             summary="List sale payments",
+            responses=RESPONSES_LIST,
         )(self.get_sale_payments)
 
     def get_all_sales(
@@ -65,6 +71,7 @@ class SaleRouter:
         query_params: SaleQueryParams = Depends(),
         meta: Meta = Depends(get_meta),
     ) -> PaginatedDataResponse[SaleResponse]:
+        """List all sales with optional filtering by customer or status. Supports pagination."""
         result = handler.handle(
             GetAllSalesQuery(**query_params.model_dump(exclude_none=True))
         )
@@ -83,6 +90,7 @@ class SaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> DataResponse[SaleResponse]:
+        """Retrieve a sale by its ID, including current status, totals, and payment status."""
         result = handler.handle(GetSaleByIdQuery(sale_id=sale_id))
         return DataResponse(data=SaleResponse.model_validate(result), meta=meta)
 
@@ -92,6 +100,7 @@ class SaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[SaleItemResponse]:
+        """List all line items for a sale."""
         result = handler.handle(GetSaleItemsQuery(sale_id=sale_id))
         return ListResponse(
             data=[SaleItemResponse.model_validate(r) for r in result], meta=meta
@@ -103,6 +112,7 @@ class SaleRouter:
         sale_id: int,
         meta: Meta = Depends(get_meta),
     ) -> ListResponse[PaymentResponse]:
+        """List all payments registered for a sale."""
         result = handler.handle(GetSalePaymentsQuery(sale_id=sale_id))
         return ListResponse(
             data=[PaymentResponse.model_validate(r) for r in result], meta=meta

--- a/src/sales/infra/validators.py
+++ b/src/sales/infra/validators.py
@@ -1,97 +1,97 @@
-"""Pydantic schemas para validación y serialización de Sales"""
+"""Pydantic schemas for Sales validation and serialization."""
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
+from src.sales.domain.entities import PaymentMethod, PaymentStatus, SaleStatus
 from src.shared.infra.validators import DecimalNumber, QueryParams
 
 
 class SaleItemRequest(BaseModel):
-    """Schema para input de un item de venta"""
+    """Add a line item to a sale."""
 
     product_id: int = Field(
         ...,
         gt=0,
-        description="ID del producto",
+        description="Product ID",
         validation_alias=AliasChoices("productId", "product_id"),
         serialization_alias="productId",
     )
-    quantity: int = Field(..., gt=0, description="Cantidad del producto")
+    quantity: int = Field(..., gt=0, description="Quantity to sell")
     unit_price: Decimal = Field(
         ...,
         gt=0,
-        description="Precio unitario",
+        description="Unit price",
         validation_alias=AliasChoices("unitPrice", "unit_price"),
         serialization_alias="unitPrice",
     )
     discount: Decimal = Field(
-        Decimal("0"), ge=0, le=100, description="Porcentaje de descuento"
+        Decimal("0"), ge=0, le=100, description="Discount percentage (0-100)"
     )
 
 
 class SaleItemUpdateRequest(BaseModel):
-    """Schema para actualizar un item de venta"""
+    """Update an existing sale line item."""
 
-    quantity: int | None = Field(None, gt=0, description="Nueva cantidad")
+    quantity: int | None = Field(None, gt=0, description="New quantity")
     discount: Decimal | None = Field(
-        None, ge=0, le=100, description="Nuevo porcentaje de descuento"
+        None, ge=0, le=100, description="New discount percentage (0-100)"
     )
 
 
 class SaleRequest(BaseModel):
-    """Schema para crear una venta"""
+    """Create a new sale in DRAFT status."""
 
     customer_id: int | None = Field(
         None,
         gt=0,
-        description="ID del cliente",
+        description="Customer ID (optional for final consumers)",
         validation_alias=AliasChoices("customerId", "customer_id"),
         serialization_alias="customerId",
     )
     is_final_consumer: bool = Field(
         False,
-        description="Indica si es consumidor final",
+        description="Whether this is a final consumer (anonymous) sale",
         validation_alias=AliasChoices("isFinalConsumer", "is_final_consumer"),
         serialization_alias="isFinalConsumer",
     )
-    notes: str | None = Field(None, max_length=512, description="Notas adicionales")
+    notes: str | None = Field(None, max_length=512, description="Additional notes")
     created_by: str | None = Field(
         None,
         max_length=64,
-        description="Usuario que crea",
+        description="User who created the sale",
         validation_alias=AliasChoices("createdBy", "created_by"),
         serialization_alias="createdBy",
     )
 
 
 class PaymentRequest(BaseModel):
-    """Schema para registrar un pago"""
+    """Register a payment against a sale."""
 
-    amount: Decimal = Field(..., gt=0, description="Monto del pago")
-    payment_method: str = Field(
+    amount: Decimal = Field(..., gt=0, description="Payment amount")
+    payment_method: PaymentMethod = Field(
         ...,
-        description="Método de pago",
+        description="Payment method",
         validation_alias=AliasChoices("paymentMethod", "payment_method"),
         serialization_alias="paymentMethod",
     )
     reference: str | None = Field(
-        None, max_length=128, description="Referencia del pago"
+        None, max_length=128, description="Payment reference (e.g. transaction ID)"
     )
-    notes: str | None = Field(None, max_length=512, description="Notas del pago")
+    notes: str | None = Field(None, max_length=512, description="Payment notes")
 
 
 class CancelSaleRequest(BaseModel):
-    """Schema para cancelar una venta"""
+    """Cancel a sale."""
 
-    reason: str | None = Field(
-        None, max_length=512, description="Razón de la cancelación"
-    )
+    reason: str | None = Field(None, max_length=512, description="Cancellation reason")
 
 
 class SaleItemResponse(BaseModel):
-    """Schema para respuesta de un item de venta"""
+    """Sale line item details."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -137,7 +137,7 @@ class SaleItemResponse(BaseModel):
 
 
 class PaymentResponse(BaseModel):
-    """Schema para respuesta de un pago"""
+    """Payment record details."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -148,8 +148,9 @@ class PaymentResponse(BaseModel):
         serialization_alias="saleId",
     )
     amount: DecimalNumber
-    payment_method: str = Field(
+    payment_method: PaymentMethod = Field(
         ...,
+        description="Payment method used",
         validation_alias=AliasChoices("paymentMethod", "payment_method"),
         serialization_alias="paymentMethod",
     )
@@ -168,7 +169,7 @@ class PaymentResponse(BaseModel):
 
 
 class SaleResponse(BaseModel):
-    """Schema para respuesta de una venta"""
+    """Sale resource details."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -188,7 +189,7 @@ class SaleResponse(BaseModel):
         validation_alias=AliasChoices("shiftId", "shift_id"),
         serialization_alias="shiftId",
     )
-    status: str
+    status: SaleStatus = Field(description="Current sale status")
     sale_date: datetime | None = Field(
         None,
         validation_alias=AliasChoices("saleDate", "sale_date"),
@@ -197,8 +198,9 @@ class SaleResponse(BaseModel):
     subtotal: DecimalNumber
     tax: DecimalNumber
     discount: DecimalNumber
-    discount_type: str | None = Field(
+    discount_type: Literal["PERCENTAGE", "AMOUNT"] | None = Field(
         None,
+        description="Type of discount applied to the sale",
         validation_alias=AliasChoices("discountType", "discount_type"),
         serialization_alias="discountType",
     )
@@ -208,8 +210,9 @@ class SaleResponse(BaseModel):
         serialization_alias="discountValue",
     )
     total: DecimalNumber
-    payment_status: str = Field(
+    payment_status: PaymentStatus = Field(
         ...,
+        description="Current payment status",
         validation_alias=AliasChoices("paymentStatus", "payment_status"),
         serialization_alias="paymentStatus",
     )
@@ -242,7 +245,7 @@ class SaleResponse(BaseModel):
 
 
 class SaleDetailResponse(SaleResponse):
-    """Schema para respuesta de una venta con items y pagos"""
+    """Sale with items and payments included."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -252,5 +255,5 @@ class SaleDetailResponse(SaleResponse):
 
 # Query Params
 class SaleQueryParams(QueryParams):
-    customer_id: int | None = Field(None, ge=1)
-    status: str | None = None
+    customer_id: int | None = Field(None, ge=1, description="Filter by customer ID")
+    status: SaleStatus | None = Field(None, description="Filter by sale status")

--- a/src/shared/infra/validators.py
+++ b/src/shared/infra/validators.py
@@ -13,16 +13,24 @@ T = TypeVar("T")
 
 
 class QueryParams(BaseModel):
+    """Base query parameters for paginated list endpoints."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
-    limit: int | None = Field(100, ge=1, le=1000)
-    offset: int | None = Field(0, ge=0)
+    limit: int | None = Field(
+        100, ge=1, le=1000, description="Maximum number of records to return (1-1000)"
+    )
+    offset: int | None = Field(
+        0, ge=0, description="Number of records to skip for pagination"
+    )
 
 
 class Meta(BaseModel):
+    """Metadata included in every API response."""
+
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-    request_id: str
-    timestamp: str
+    request_id: str = Field(description="Unique identifier for this request (UUID v4)")
+    timestamp: str = Field(description="ISO 8601 timestamp of the response")
 
     def with_pagination(self, total: int, limit: int, offset: int) -> "PaginatedMeta":
         return PaginatedMeta(
@@ -33,36 +41,124 @@ class Meta(BaseModel):
 
 
 class PaginationMeta(BaseModel):
-    total: int
-    limit: int
-    offset: int
+    """Pagination details returned in paginated list responses."""
+
+    total: int = Field(description="Total number of records matching the query")
+    limit: int = Field(description="Maximum records per page (as requested)")
+    offset: int = Field(description="Number of records skipped (as requested)")
 
 
 class PaginatedMeta(Meta):
-    pagination: PaginationMeta
+    """Response metadata with pagination information."""
+
+    pagination: PaginationMeta = Field(description="Pagination details")
 
 
 class DataResponse(BaseModel, Generic[T]):
-    data: T
-    meta: Meta
+    """Standard wrapper for a single-resource response."""
+
+    data: T = Field(description="The requested resource")
+    meta: Meta = Field(description="Response metadata")
 
 
 class ListResponse(BaseModel, Generic[T]):
-    data: list[T]
-    meta: Meta
+    """Standard wrapper for a non-paginated list response."""
+
+    data: list[T] = Field(description="List of resources")
+    meta: Meta = Field(description="Response metadata")
 
 
 class PaginatedDataResponse(BaseModel, Generic[T]):
-    data: list[T]
-    meta: PaginatedMeta
+    """Standard wrapper for a paginated list response."""
+
+    data: list[T] = Field(description="List of resources for the current page")
+    meta: PaginatedMeta = Field(
+        description="Response metadata including pagination details"
+    )
 
 
 class ErrorDetail(BaseModel):
-    code: str
-    message: str
-    field: str | None = None
+    """Individual error entry within an error response."""
+
+    code: str = Field(
+        description="Machine-readable error code (e.g. NOT_FOUND, DOMAIN_ERROR, VALIDATION_ERROR)"
+    )
+    message: str = Field(description="Human-readable error description")
+    field: str | None = Field(
+        None,
+        description="Dot-path to the field that caused the error, if applicable",
+    )
 
 
 class ErrorResponse(BaseModel):
-    errors: list[ErrorDetail]
-    meta: Meta
+    """Standard error response returned by all endpoints on failure.
+
+    Example:
+    ```json
+    {
+      "errors": [
+        {"code": "NOT_FOUND", "message": "Product with id 99 not found"}
+      ],
+      "meta": {
+        "requestId": "550e8400-e29b-41d4-a716-446655440000",
+        "timestamp": "2025-01-15T10:30:00Z"
+      }
+    }
+    ```
+    """
+
+    errors: list[ErrorDetail] = Field(description="List of error details")
+    meta: Meta = Field(description="Response metadata")
+
+
+# ---------------------------------------------------------------------------
+# Reusable OpenAPI error-response definitions
+# ---------------------------------------------------------------------------
+
+_ERR_400: dict = {
+    "description": "**Business rule violation** — the request conflicts with domain rules (e.g. confirming an already-confirmed sale).",
+    "model": ErrorResponse,
+}
+_ERR_404: dict = {
+    "description": "**Resource not found** — the requested entity does not exist.",
+    "model": ErrorResponse,
+}
+_ERR_409: dict = {
+    "description": "**Integrity conflict** — the resource is referenced by other records and cannot be modified or deleted.",
+    "model": ErrorResponse,
+}
+_ERR_422: dict = {
+    "description": "**Validation error** — the request body or query parameters failed validation.",
+    "model": ErrorResponse,
+}
+_ERR_500: dict = {
+    "description": "**Internal server error** — an unexpected error occurred.",
+    "model": ErrorResponse,
+}
+
+RESPONSES_LIST: dict[int | str, dict] = {400: _ERR_400, 422: _ERR_422, 500: _ERR_500}
+"""Error responses for list/search endpoints."""
+
+RESPONSES_QUERY: dict[int | str, dict] = {
+    400: _ERR_400,
+    404: _ERR_404,
+    422: _ERR_422,
+    500: _ERR_500,
+}
+"""Error responses for single-resource GET endpoints."""
+
+RESPONSES_COMMAND: dict[int | str, dict] = {
+    400: _ERR_400,
+    404: _ERR_404,
+    409: _ERR_409,
+    422: _ERR_422,
+    500: _ERR_500,
+}
+"""Error responses for create/update/action endpoints."""
+
+RESPONSES_DELETE: dict[int | str, dict] = {
+    404: _ERR_404,
+    409: _ERR_409,
+    500: _ERR_500,
+}
+"""Error responses for delete endpoints."""

--- a/src/suppliers/infra/routes.py
+++ b/src/suppliers/infra/routes.py
@@ -3,6 +3,10 @@ from wireup import Injected
 
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_DELETE,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
     DataResponse,
     ListResponse,
     Meta,
@@ -78,52 +82,64 @@ class SupplierRouter:
             "",
             response_model=DataResponse[SupplierResponse],
             summary="Create supplier",
+            responses=RESPONSES_COMMAND,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[SupplierResponse],
             summary="Update supplier",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete supplier")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete supplier", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[SupplierResponse],
             summary="Get all suppliers",
+            responses=RESPONSES_LIST,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierResponse],
             summary="Get supplier by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.post(
             "/{id}/activate",
             response_model=DataResponse[SupplierResponse],
             summary="Activate supplier",
+            responses=RESPONSES_COMMAND,
         )(self.activate)
         self.router.post(
             "/{id}/deactivate",
             response_model=DataResponse[SupplierResponse],
             summary="Deactivate supplier",
+            responses=RESPONSES_COMMAND,
         )(self.deactivate)
         self.router.post(
             "/{supplier_id}/contacts",
             response_model=DataResponse[SupplierContactResponse],
             summary="Create supplier contact",
+            responses=RESPONSES_COMMAND,
         )(self.create_contact)
         self.router.get(
             "/{supplier_id}/contacts",
             response_model=ListResponse[SupplierContactResponse],
             summary="Get supplier contacts",
+            responses=RESPONSES_LIST,
         )(self.get_supplier_contacts)
         self.router.post(
             "/{supplier_id}/products",
             response_model=DataResponse[SupplierProductResponse],
             summary="Add product to supplier catalog",
+            responses=RESPONSES_COMMAND,
         )(self.create_supplier_product)
         self.router.get(
             "/{supplier_id}/products",
             response_model=ListResponse[SupplierProductResponse],
             summary="Get supplier products",
+            responses=RESPONSES_LIST,
         )(self.get_supplier_products)
 
     def create(
@@ -283,12 +299,16 @@ class SupplierContactRouter:
             "/{id}",
             response_model=DataResponse[SupplierContactResponse],
             summary="Update supplier contact",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete supplier contact")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete supplier contact", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierContactResponse],
             summary="Get supplier contact by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
 
     def update(
@@ -338,17 +358,22 @@ class SupplierProductRouter:
             "/{id}",
             response_model=DataResponse[SupplierProductResponse],
             summary="Update supplier product",
+            responses=RESPONSES_COMMAND,
         )(self.update)
-        self.router.delete("/{id}", summary="Delete supplier product")(self.delete)
+        self.router.delete(
+            "/{id}", summary="Delete supplier product", responses=RESPONSES_DELETE
+        )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierProductResponse],
             summary="Get supplier product by ID",
+            responses=RESPONSES_QUERY,
         )(self.get_by_id)
         self.router.get(
             "/by-product/{product_id}",
             response_model=ListResponse[SupplierProductResponse],
             summary="Get all suppliers for a product",
+            responses=RESPONSES_LIST,
         )(self.get_by_product)
 
     def update(


### PR DESCRIPTION
## Descripción

   Remove redundant 'admin - ' / 'pos - ' prefixes from OpenAPI tags and use
   clean capitalized names (e.g. 'Categories' instead of 'admin - categories').
   Tag groups already provide the section context, so the prefix was visual noise.
   Also switch _filtered_schema to filter by URL path prefix instead of tag name
   prefix for correctness with the new naming.


## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [ ] Nueva funcionalidad (feature)
- [ ] Corrección de bug (fix)
- [x] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
