### PR TITLE
feat: add JWT login, refresh and auth middleware

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,9 @@ from wireup.integration.fastapi import setup as wireup_fastapi_setup
 
 import src
 from config import config
+from src.auth.infra.middleware import AuthMiddleware
+from src.auth.infra.routes import AuthRouter
+from src.auth.infra.token_service import JwtTokenService
 from src.catalog.product.infra.routes import CategoryRouter, ProductRouter
 from src.catalog.uom.infra.routes import UnitOfMeasureRouter
 from src.container import create_wireup_container
@@ -267,10 +270,15 @@ pos_router.include_router(
     POSReportRouter().router, prefix="/reports", tags=["POS Reports"]
 )
 
+# Auth API
+auth_router = APIRouter(prefix="/api/auth")
+auth_router.include_router(AuthRouter().router, tags=["Auth"])
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
 
+app.add_middleware(AuthMiddleware, token_service=JwtTokenService())
 app.add_middleware(ErrorHandlingMiddleware)
 app.add_middleware(
     CORSMiddleware,
@@ -282,6 +290,7 @@ app.add_middleware(
 
 app.include_router(admin_router)
 app.include_router(pos_router)
+app.include_router(auth_router)
 
 # ---------------------------------------------------------------------------
 # Doc endpoints (only registered when DOCS_ENABLED=true)

--- a/src/auth/app/commands/login.py
+++ b/src/auth/app/commands/login.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.auth.app.services.password_hasher import PasswordHasher
+from src.auth.app.services.token_service import TokenPair, TokenService
+from src.auth.domain.events import UserLoggedIn
+from src.auth.domain.exceptions import InvalidCredentialsError
+from src.shared.app.commands import Command, CommandHandler
+from src.shared.app.events import EventPublisher
+
+
+@dataclass
+class LoginCommand(Command):
+    username: str = ""
+    password: str = ""
+
+
+@injectable(lifetime="scoped")
+class LoginCommandHandler(CommandHandler[LoginCommand, TokenPair]):
+    def __init__(
+        self,
+        repo: UserRepository,
+        hasher: PasswordHasher,
+        token_service: TokenService,
+        event_publisher: EventPublisher,
+    ):
+        self.repo = repo
+        self.hasher = hasher
+        self.token_service = token_service
+        self.event_publisher = event_publisher
+
+    def _handle(self, command: LoginCommand) -> TokenPair:
+        user = self.repo.get_by_username(command.username)
+        if user is None or not user.is_active:
+            raise InvalidCredentialsError("invalid username or password")
+        if not self.hasher.verify(command.password, user.password_hash):
+            raise InvalidCredentialsError("invalid username or password")
+
+        user = replace(user, last_login_at=datetime.now(UTC))
+        user = self.repo.update(user)
+
+        self.event_publisher.publish(
+            UserLoggedIn(
+                aggregate_id=user.id,
+                user_id=user.id,
+                username=user.username,
+            )
+        )
+
+        return self.token_service.issue_pair(user)

--- a/src/auth/app/commands/refresh_token.py
+++ b/src/auth/app/commands/refresh_token.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.auth.app.services.token_service import TokenPair, TokenService
+from src.auth.domain.exceptions import InvalidTokenError
+from src.shared.app.commands import Command, CommandHandler
+
+
+@dataclass
+class RefreshTokenCommand(Command):
+    refresh_token: str = ""
+
+
+@injectable(lifetime="scoped")
+class RefreshTokenCommandHandler(CommandHandler[RefreshTokenCommand, TokenPair]):
+    def __init__(self, repo: UserRepository, token_service: TokenService):
+        self.repo = repo
+        self.token_service = token_service
+
+    def _handle(self, command: RefreshTokenCommand) -> TokenPair:
+        claims = self.token_service.decode_refresh(command.refresh_token)
+        user = self.repo.get_by_id(claims.sub)
+        if user is None or not user.is_active:
+            raise InvalidTokenError("user no longer valid")
+        return self.token_service.issue_pair(user)

--- a/src/auth/app/services/token_service.py
+++ b/src/auth/app/services/token_service.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Literal
+
+from src.auth.domain.entities import User
+
+TokenType = Literal["access", "refresh"]
+
+
+@dataclass(frozen=True)
+class TokenPair:
+    access_token: str
+    refresh_token: str
+    expires_in: int
+    token_type: str = "Bearer"
+
+
+@dataclass(frozen=True)
+class TokenClaims:
+    sub: int
+    username: str
+    role: int
+    typ: TokenType
+    iat: int
+    exp: int
+    iss: str
+
+
+class TokenService(ABC):
+    @abstractmethod
+    def issue_pair(self, user: User) -> TokenPair: ...
+
+    @abstractmethod
+    def decode_access(self, token: str) -> TokenClaims: ...
+
+    @abstractmethod
+    def decode_refresh(self, token: str) -> TokenClaims: ...

--- a/src/auth/domain/entities.py
+++ b/src/auth/domain/entities.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum
 
@@ -22,3 +22,11 @@ class User(Entity):
     is_active: bool = True
     last_login_at: datetime | None = None
     created_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    id: int
+    username: str
+    role: Role
+    permissions: frozenset = field(default_factory=frozenset)

--- a/src/auth/domain/events.py
+++ b/src/auth/domain/events.py
@@ -18,3 +18,15 @@ class UserCreated(DomainEvent):
             "email": self.email,
             "role": self.role,
         }
+
+
+@dataclass
+class UserLoggedIn(DomainEvent):
+    user_id: int = 0
+    username: str = ""
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "username": self.username,
+        }

--- a/src/auth/infra/container.py
+++ b/src/auth/infra/container.py
@@ -1,11 +1,17 @@
 from src.auth.app.commands.create_user import CreateUserCommandHandler
+from src.auth.app.commands.login import LoginCommandHandler
+from src.auth.app.commands.refresh_token import RefreshTokenCommandHandler
 from src.auth.infra.mappers import UserMapper
 from src.auth.infra.password_hasher import BcryptPasswordHasher
 from src.auth.infra.repositories import SqlAlchemyUserRepository
+from src.auth.infra.token_service import JwtTokenService
 
 INJECTABLES = [
     UserMapper,
     BcryptPasswordHasher,
+    JwtTokenService,
     SqlAlchemyUserRepository,
     CreateUserCommandHandler,
+    LoginCommandHandler,
+    RefreshTokenCommandHandler,
 ]

--- a/src/auth/infra/dependencies.py
+++ b/src/auth/infra/dependencies.py
@@ -1,0 +1,38 @@
+from fastapi import Depends, Request
+
+from src.auth.domain.entities import AuthenticatedUser
+from src.auth.domain.exceptions import (
+    InvalidTokenError,
+    PermissionDeniedError,
+    TokenExpiredError,
+)
+from src.auth.domain.permissions import Permission
+
+
+def get_optional_user(request: Request) -> AuthenticatedUser | None:
+    return getattr(request.state, "current_user", None)
+
+
+def get_current_user(request: Request) -> AuthenticatedUser:
+    user = getattr(request.state, "current_user", None)
+    if user is not None:
+        return user
+
+    reason = getattr(request.state, "auth_error", None)
+    if reason == "token_expired":
+        raise TokenExpiredError("access token expired")
+    if reason == "invalid_token":
+        raise InvalidTokenError("invalid access token")
+    raise PermissionDeniedError("authentication required")
+
+
+def require_permission(*required: Permission):
+    def _dep(
+        user: AuthenticatedUser = Depends(get_current_user),
+    ) -> AuthenticatedUser:
+        if not set(required).issubset(user.permissions):
+            missing = [p.value for p in required if p not in user.permissions]
+            raise PermissionDeniedError(f"missing permissions: {missing}")
+        return user
+
+    return _dep

--- a/src/auth/infra/middleware.py
+++ b/src/auth/infra/middleware.py
@@ -1,0 +1,35 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from src.auth.app.services.token_service import TokenService
+from src.auth.domain.entities import AuthenticatedUser, Role
+from src.auth.domain.exceptions import InvalidTokenError, TokenExpiredError
+from src.auth.domain.permissions import permissions_for
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, token_service: TokenService):
+        super().__init__(app)
+        self._token_service = token_service
+
+    async def dispatch(self, request, call_next):
+        request.state.current_user = None
+        request.state.auth_error = None
+
+        header = request.headers.get("authorization")
+        if header and header.lower().startswith("bearer "):
+            token = header.split(" ", 1)[1].strip()
+            try:
+                claims = self._token_service.decode_access(token)
+                role = Role(claims.role)
+                request.state.current_user = AuthenticatedUser(
+                    id=claims.sub,
+                    username=claims.username,
+                    role=role,
+                    permissions=permissions_for(role),
+                )
+            except TokenExpiredError:
+                request.state.auth_error = "token_expired"
+            except InvalidTokenError:
+                request.state.auth_error = "invalid_token"
+
+        return await call_next(request)

--- a/src/auth/infra/routes.py
+++ b/src/auth/infra/routes.py
@@ -1,0 +1,103 @@
+from fastapi import APIRouter, Depends
+from wireup import Injected
+
+from src.auth.app.commands.login import LoginCommand, LoginCommandHandler
+from src.auth.app.commands.refresh_token import (
+    RefreshTokenCommand,
+    RefreshTokenCommandHandler,
+)
+from src.auth.domain.entities import AuthenticatedUser
+from src.auth.infra.dependencies import get_current_user
+from src.auth.infra.validators import (
+    AuthenticatedUserResponse,
+    LoginRequest,
+    RefreshRequest,
+    TokenPairResponse,
+)
+from src.shared.infra.dependencies import get_meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+)
+
+
+class AuthRouter:
+    def __init__(self):
+        self.router = APIRouter()
+        self._setup_routes()
+
+    def _setup_routes(self):
+        self.router.post(
+            "/login",
+            response_model=DataResponse[TokenPairResponse],
+            summary="Login with username and password",
+            responses=RESPONSES_COMMAND,
+        )(self.login)
+        self.router.post(
+            "/refresh",
+            response_model=DataResponse[TokenPairResponse],
+            summary="Refresh an access token",
+            responses=RESPONSES_COMMAND,
+        )(self.refresh)
+        self.router.get(
+            "/me",
+            response_model=DataResponse[AuthenticatedUserResponse],
+            summary="Get the currently authenticated user",
+            responses=RESPONSES_QUERY,
+        )(self.me)
+
+    def login(
+        self,
+        handler: Injected[LoginCommandHandler],
+        credentials: LoginRequest,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[TokenPairResponse]:
+        pair = handler.handle(
+            LoginCommand(
+                username=credentials.username,
+                password=credentials.password,
+            )
+        )
+        return DataResponse(
+            data=TokenPairResponse(
+                access_token=pair.access_token,
+                refresh_token=pair.refresh_token,
+                token_type=pair.token_type,
+                expires_in=pair.expires_in,
+            ),
+            meta=meta,
+        )
+
+    def refresh(
+        self,
+        handler: Injected[RefreshTokenCommandHandler],
+        request: RefreshRequest,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[TokenPairResponse]:
+        pair = handler.handle(RefreshTokenCommand(refresh_token=request.refresh_token))
+        return DataResponse(
+            data=TokenPairResponse(
+                access_token=pair.access_token,
+                refresh_token=pair.refresh_token,
+                token_type=pair.token_type,
+                expires_in=pair.expires_in,
+            ),
+            meta=meta,
+        )
+
+    def me(
+        self,
+        user: AuthenticatedUser = Depends(get_current_user),
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[AuthenticatedUserResponse]:
+        return DataResponse(
+            data=AuthenticatedUserResponse(
+                id=user.id,
+                username=user.username,
+                role=int(user.role),
+                permissions=sorted(p.value for p in user.permissions),
+            ),
+            meta=meta,
+        )

--- a/src/auth/infra/token_service.py
+++ b/src/auth/infra/token_service.py
@@ -1,0 +1,85 @@
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from wireup import injectable
+
+from config import config
+from src.auth.app.services.token_service import (
+    TokenClaims,
+    TokenPair,
+    TokenService,
+    TokenType,
+)
+from src.auth.domain.entities import User
+from src.auth.domain.exceptions import InvalidTokenError, TokenExpiredError
+
+_ALGORITHM = "HS256"
+
+
+@injectable(lifetime="singleton", as_type=TokenService)
+class JwtTokenService(TokenService):
+    def __init__(self):
+        self._secret = config.JWT_SECRET
+        self._access_ttl = config.JWT_ACCESS_TTL_SECONDS
+        self._refresh_ttl = config.JWT_REFRESH_TTL_SECONDS
+        self._issuer = config.JWT_ISSUER
+
+    def issue_pair(self, user: User) -> TokenPair:
+        access = self._encode(user, "access", self._access_ttl)
+        refresh = self._encode(user, "refresh", self._refresh_ttl)
+        return TokenPair(
+            access_token=access,
+            refresh_token=refresh,
+            expires_in=self._access_ttl,
+        )
+
+    def decode_access(self, token: str) -> TokenClaims:
+        return self._decode(token, expected_typ="access")
+
+    def decode_refresh(self, token: str) -> TokenClaims:
+        return self._decode(token, expected_typ="refresh")
+
+    def _encode(self, user: User, typ: TokenType, ttl_seconds: int) -> str:
+        now = datetime.now(UTC)
+        payload = {
+            "sub": str(user.id),
+            "username": user.username,
+            "role": int(user.role),
+            "typ": typ,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(seconds=ttl_seconds)).timestamp()),
+            "iss": self._issuer,
+        }
+        return jwt.encode(payload, self._secret, algorithm=_ALGORITHM)
+
+    def _decode(self, token: str, expected_typ: TokenType) -> TokenClaims:
+        try:
+            payload = jwt.decode(
+                token,
+                self._secret,
+                algorithms=[_ALGORITHM],
+                issuer=self._issuer,
+                options={"require": ["exp", "iat", "iss", "sub", "typ"]},
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise TokenExpiredError("token expired") from exc
+        except jwt.PyJWTError as exc:
+            raise InvalidTokenError(f"invalid token: {exc}") from exc
+
+        if payload.get("typ") != expected_typ:
+            raise InvalidTokenError(
+                f"expected {expected_typ} token, got {payload.get('typ')}"
+            )
+
+        try:
+            return TokenClaims(
+                sub=int(payload["sub"]),
+                username=payload["username"],
+                role=int(payload["role"]),
+                typ=payload["typ"],
+                iat=int(payload["iat"]),
+                exp=int(payload["exp"]),
+                iss=payload["iss"],
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise InvalidTokenError("malformed token claims") from exc

--- a/src/auth/infra/validators.py
+++ b/src/auth/infra/validators.py
@@ -1,0 +1,34 @@
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class LoginRequest(BaseModel):
+    username: str = Field(..., min_length=1, max_length=64)
+    password: str = Field(..., min_length=1, max_length=128)
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str = Field(
+        ...,
+        min_length=1,
+        validation_alias=AliasChoices("refreshToken", "refresh_token"),
+        serialization_alias="refreshToken",
+    )
+
+
+class TokenPairResponse(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    access_token: str = Field(description="Short-lived access token")
+    refresh_token: str = Field(description="Long-lived refresh token")
+    token_type: str = Field("Bearer", description="Token scheme")
+    expires_in: int = Field(description="Access token lifetime in seconds")
+
+
+class AuthenticatedUserResponse(BaseModel):
+    id: int = Field(ge=1)
+    username: str
+    role: int = Field(
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)"
+    )
+    permissions: list[str] = Field(default_factory=list)

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.auth.domain.entities import AuthenticatedUser, Role
+from src.auth.domain.exceptions import (
+    InvalidTokenError,
+    PermissionDeniedError,
+    TokenExpiredError,
+)
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import (
+    get_current_user,
+    get_optional_user,
+    require_permission,
+)
+
+
+def _request(**state):
+    return SimpleNamespace(state=SimpleNamespace(**state))
+
+
+def _admin() -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=1,
+        username="admin",
+        role=Role.ADMIN,
+        permissions=frozenset({Permission.USER_MANAGE}),
+    )
+
+
+def test_get_optional_user_returns_none_when_missing():
+    assert get_optional_user(_request(current_user=None)) is None
+
+
+def test_get_optional_user_returns_user_when_present():
+    user = _admin()
+    assert get_optional_user(_request(current_user=user)) is user
+
+
+def test_get_current_user_raises_permission_denied_when_no_header():
+    with pytest.raises(PermissionDeniedError):
+        get_current_user(_request(current_user=None, auth_error=None))
+
+
+def test_get_current_user_raises_token_expired():
+    with pytest.raises(TokenExpiredError):
+        get_current_user(_request(current_user=None, auth_error="token_expired"))
+
+
+def test_get_current_user_raises_invalid_token():
+    with pytest.raises(InvalidTokenError):
+        get_current_user(_request(current_user=None, auth_error="invalid_token"))
+
+
+def test_get_current_user_returns_user():
+    user = _admin()
+    assert get_current_user(_request(current_user=user)) is user
+
+
+def test_require_permission_allows_when_user_has_all():
+    user = _admin()
+    dep = require_permission(Permission.USER_MANAGE)
+    assert dep(user=user) is user
+
+
+def test_require_permission_raises_when_missing():
+    user = AuthenticatedUser(
+        id=2,
+        username="viewer",
+        role=Role.VIEWER,
+        permissions=frozenset(),
+    )
+    dep = require_permission(Permission.USER_MANAGE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=user)

--- a/tests/unit/auth/test_login_command.py
+++ b/tests/unit/auth/test_login_command.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.auth.app.commands.login import LoginCommand, LoginCommandHandler
+from src.auth.app.services.token_service import TokenPair
+from src.auth.domain.entities import Role, User
+from src.auth.domain.events import UserLoggedIn
+from src.auth.domain.exceptions import InvalidCredentialsError
+
+
+def _user(**overrides) -> User:
+    defaults = {
+        "id": 1,
+        "username": "alice",
+        "email": "alice@example.com",
+        "password_hash": "hashed",
+        "role": Role.ADMIN,
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _handler(user=None, verify=True):
+    repo = MagicMock()
+    repo.get_by_username.return_value = user
+    repo.update.side_effect = lambda u: u
+    hasher = MagicMock()
+    hasher.verify.return_value = verify
+    token_service = MagicMock()
+    token_service.issue_pair.return_value = TokenPair(
+        access_token="a", refresh_token="r", expires_in=900
+    )
+    publisher = MagicMock()
+    return LoginCommandHandler(repo, hasher, token_service, publisher), repo, publisher
+
+
+def test_login_with_valid_credentials_returns_pair_and_updates_last_login():
+    handler, repo, publisher = _handler(user=_user())
+    result = handler.handle(LoginCommand(username="alice", password="pw"))
+
+    assert result.access_token == "a"
+    assert result.refresh_token == "r"
+    repo.update.assert_called_once()
+    updated = repo.update.call_args[0][0]
+    assert updated.last_login_at is not None
+
+    publisher.publish.assert_called_once()
+    event = publisher.publish.call_args[0][0]
+    assert isinstance(event, UserLoggedIn)
+    assert event.user_id == 1
+    assert event.username == "alice"
+
+
+def test_login_unknown_user_raises_invalid_credentials():
+    handler, *_ = _handler(user=None)
+    with pytest.raises(InvalidCredentialsError):
+        handler.handle(LoginCommand(username="ghost", password="pw"))
+
+
+def test_login_inactive_user_raises_invalid_credentials():
+    handler, *_ = _handler(user=_user(is_active=False))
+    with pytest.raises(InvalidCredentialsError):
+        handler.handle(LoginCommand(username="alice", password="pw"))
+
+
+def test_login_wrong_password_raises_invalid_credentials():
+    handler, *_ = _handler(user=_user(), verify=False)
+    with pytest.raises(InvalidCredentialsError):
+        handler.handle(LoginCommand(username="alice", password="bad"))

--- a/tests/unit/auth/test_refresh_token_command.py
+++ b/tests/unit/auth/test_refresh_token_command.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.auth.app.commands.refresh_token import (
+    RefreshTokenCommand,
+    RefreshTokenCommandHandler,
+)
+from src.auth.app.services.token_service import TokenClaims, TokenPair
+from src.auth.domain.entities import Role, User
+from src.auth.domain.exceptions import InvalidTokenError
+
+
+def _user(**overrides) -> User:
+    defaults = {
+        "id": 1,
+        "username": "alice",
+        "email": "alice@example.com",
+        "password_hash": "h",
+        "role": Role.ADMIN,
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _claims() -> TokenClaims:
+    return TokenClaims(
+        sub=1,
+        username="alice",
+        role=1,
+        typ="refresh",
+        iat=0,
+        exp=0,
+        iss="faclab",
+    )
+
+
+def test_refresh_valid_returns_new_pair():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _user()
+    token_service = MagicMock()
+    token_service.decode_refresh.return_value = _claims()
+    token_service.issue_pair.return_value = TokenPair(
+        access_token="a2", refresh_token="r2", expires_in=900
+    )
+
+    handler = RefreshTokenCommandHandler(repo, token_service)
+    result = handler.handle(RefreshTokenCommand(refresh_token="old"))
+
+    assert result.access_token == "a2"
+    token_service.decode_refresh.assert_called_once_with("old")
+    token_service.issue_pair.assert_called_once()
+
+
+def test_refresh_inactive_user_raises_invalid_token():
+    repo = MagicMock()
+    repo.get_by_id.return_value = _user(is_active=False)
+    token_service = MagicMock()
+    token_service.decode_refresh.return_value = _claims()
+
+    handler = RefreshTokenCommandHandler(repo, token_service)
+    with pytest.raises(InvalidTokenError):
+        handler.handle(RefreshTokenCommand(refresh_token="old"))
+
+
+def test_refresh_unknown_user_raises_invalid_token():
+    repo = MagicMock()
+    repo.get_by_id.return_value = None
+    token_service = MagicMock()
+    token_service.decode_refresh.return_value = _claims()
+
+    handler = RefreshTokenCommandHandler(repo, token_service)
+    with pytest.raises(InvalidTokenError):
+        handler.handle(RefreshTokenCommand(refresh_token="old"))
+
+
+def test_refresh_propagates_invalid_token_from_service():
+    repo = MagicMock()
+    token_service = MagicMock()
+    token_service.decode_refresh.side_effect = InvalidTokenError("bad typ")
+
+    handler = RefreshTokenCommandHandler(repo, token_service)
+    with pytest.raises(InvalidTokenError):
+        handler.handle(RefreshTokenCommand(refresh_token="access-token"))
+    repo.get_by_id.assert_not_called()

--- a/tests/unit/auth/test_token_service.py
+++ b/tests/unit/auth/test_token_service.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import jwt
+import pytest
+
+from src.auth.domain.entities import Role, User
+from src.auth.domain.exceptions import InvalidTokenError, TokenExpiredError
+from src.auth.infra.token_service import JwtTokenService
+
+
+def _user(**overrides) -> User:
+    defaults = {
+        "id": 42,
+        "username": "alice",
+        "email": "alice@example.com",
+        "password_hash": "hash",
+        "role": Role.ADMIN,
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def _service(**config_overrides) -> JwtTokenService:
+    defaults = {
+        "JWT_SECRET": "test-secret",
+        "JWT_ACCESS_TTL_SECONDS": 900,
+        "JWT_REFRESH_TTL_SECONDS": 7200,
+        "JWT_ISSUER": "faclab-test",
+    }
+    defaults.update(config_overrides)
+    with patch("src.auth.infra.token_service.config") as mock_cfg:
+        for k, v in defaults.items():
+            setattr(mock_cfg, k, v)
+        return JwtTokenService()
+
+
+def test_issue_pair_and_decode_round_trip():
+    svc = _service()
+    pair = svc.issue_pair(_user())
+
+    assert pair.token_type == "Bearer"
+    assert pair.expires_in == 900
+    assert pair.access_token and pair.refresh_token
+
+    access_claims = svc.decode_access(pair.access_token)
+    assert access_claims.sub == 42
+    assert access_claims.username == "alice"
+    assert access_claims.role == int(Role.ADMIN)
+    assert access_claims.typ == "access"
+    assert access_claims.iss == "faclab-test"
+
+    refresh_claims = svc.decode_refresh(pair.refresh_token)
+    assert refresh_claims.typ == "refresh"
+    assert refresh_claims.sub == 42
+
+
+def test_access_decoded_as_refresh_raises_invalid_token():
+    svc = _service()
+    pair = svc.issue_pair(_user())
+    with pytest.raises(InvalidTokenError):
+        svc.decode_refresh(pair.access_token)
+
+
+def test_refresh_decoded_as_access_raises_invalid_token():
+    svc = _service()
+    pair = svc.issue_pair(_user())
+    with pytest.raises(InvalidTokenError):
+        svc.decode_access(pair.refresh_token)
+
+
+def test_token_signed_with_other_secret_raises():
+    svc = _service(JWT_SECRET="secret-a")
+    pair = svc.issue_pair(_user())
+
+    evil = _service(JWT_SECRET="secret-b")
+    with pytest.raises(InvalidTokenError):
+        evil.decode_access(pair.access_token)
+
+
+def test_expired_token_raises_token_expired():
+    svc = _service()
+    now = datetime.now(UTC) - timedelta(seconds=60)
+    payload = {
+        "sub": "1",
+        "username": "u",
+        "role": 1,
+        "typ": "access",
+        "iat": int((now - timedelta(seconds=10)).timestamp()),
+        "exp": int(now.timestamp()),
+        "iss": "faclab-test",
+    }
+    token = jwt.encode(payload, "test-secret", algorithm="HS256")
+
+    with pytest.raises(TokenExpiredError):
+        svc.decode_access(token)
+
+
+def test_garbage_token_raises_invalid_token():
+    svc = _service()
+    with pytest.raises(InvalidTokenError):
+        svc.decode_access("not-a-jwt")
+
+
+def test_wrong_issuer_raises_invalid_token():
+    svc = _service(JWT_ISSUER="faclab-a")
+    pair = svc.issue_pair(_user())
+
+    other = _service(JWT_ISSUER="faclab-b")
+    with pytest.raises(InvalidTokenError):
+        other.decode_access(pair.access_token)


### PR DESCRIPTION
## Descripción

  - TokenService interface + JwtTokenService (HS256, PyJWT)
  - LoginCommand: validates credentials, updates last_login_at, publishes UserLoggedIn
  - RefreshTokenCommand: reloads user from DB to capture role/active changes
  - AuthMiddleware: soft middleware that populates request.state.current_user
  - FastAPI dependencies: get_current_user, get_optional_user, require_permission
  - AuthRouter: POST /api/auth/login, POST /api/auth/refresh, GET /api/auth/me
  - 23 unit tests covering token service, login, refresh and dependencies

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [x] Nueva funcionalidad (feature)
- [ ] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
