### PR TITLE
feat: add authorization, user management and permission enforcement

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from wireup.integration.fastapi import setup as wireup_fastapi_setup
 
 import src
 from config import config
+from src.auth.infra.admin_routes import UserAdminRouter
 from src.auth.infra.middleware import AuthMiddleware
 from src.auth.infra.routes import AuthRouter
 from src.auth.infra.token_service import JwtTokenService
@@ -246,6 +247,7 @@ admin_router.include_router(
     tags=["Transfer Items"],
 )
 admin_router.include_router(AlertRouter().router, prefix="/alerts", tags=["Alerts"])
+admin_router.include_router(UserAdminRouter().router, prefix="/users", tags=["Users"])
 admin_router.include_router(
     ReportRouter().router,
     prefix="/reports/inventory",

--- a/src/auth/app/commands/activate_user.py
+++ b/src/auth/app/commands/activate_user.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, replace
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.shared.app.commands import Command, CommandHandler
+from src.shared.domain.exceptions import NotFoundError
+
+
+@dataclass
+class ActivateUserCommand(Command):
+    user_id: int = 0
+
+
+@injectable(lifetime="scoped")
+class ActivateUserCommandHandler(CommandHandler[ActivateUserCommand, dict]):
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def _handle(self, command: ActivateUserCommand) -> dict:
+        user = self.repo.get_by_id(command.user_id)
+        if user is None:
+            raise NotFoundError(f"User with id {command.user_id} not found")
+
+        user = replace(user, is_active=True)
+        user = self.repo.update(user)
+        return user.dict()

--- a/src/auth/app/commands/change_password.py
+++ b/src/auth/app/commands/change_password.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, replace
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.auth.app.services.password_hasher import PasswordHasher
+from src.auth.domain.events import UserPasswordChanged
+from src.auth.domain.exceptions import InvalidCredentialsError
+from src.auth.domain.value_objects import PlainPassword
+from src.shared.app.commands import Command, CommandHandler
+from src.shared.app.events import EventPublisher
+from src.shared.domain.exceptions import NotFoundError
+
+
+@dataclass
+class ChangePasswordCommand(Command):
+    user_id: int = 0
+    current_password: str = ""
+    new_password: str = ""
+
+
+@injectable(lifetime="scoped")
+class ChangePasswordCommandHandler(CommandHandler[ChangePasswordCommand, None]):
+    def __init__(
+        self,
+        repo: UserRepository,
+        hasher: PasswordHasher,
+        event_publisher: EventPublisher,
+    ):
+        self.repo = repo
+        self.hasher = hasher
+        self.event_publisher = event_publisher
+
+    def _handle(self, command: ChangePasswordCommand) -> None:
+        user = self.repo.get_by_id(command.user_id)
+        if user is None:
+            raise NotFoundError(f"User with id {command.user_id} not found")
+
+        PlainPassword(command.new_password)
+
+        if not self.hasher.verify(command.current_password, user.password_hash):
+            raise InvalidCredentialsError("current password is incorrect")
+
+        new_hash = self.hasher.hash(command.new_password)
+        user = replace(user, password_hash=new_hash)
+        self.repo.update(user)
+
+        self.event_publisher.publish(
+            UserPasswordChanged(
+                aggregate_id=user.id,
+                user_id=user.id,
+                username=user.username,
+            )
+        )

--- a/src/auth/app/commands/deactivate_user.py
+++ b/src/auth/app/commands/deactivate_user.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, replace
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.shared.app.commands import Command, CommandHandler
+from src.shared.domain.exceptions import NotFoundError
+
+
+@dataclass
+class DeactivateUserCommand(Command):
+    user_id: int = 0
+
+
+@injectable(lifetime="scoped")
+class DeactivateUserCommandHandler(CommandHandler[DeactivateUserCommand, dict]):
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def _handle(self, command: DeactivateUserCommand) -> dict:
+        user = self.repo.get_by_id(command.user_id)
+        if user is None:
+            raise NotFoundError(f"User with id {command.user_id} not found")
+
+        user = replace(user, is_active=False)
+        user = self.repo.update(user)
+        return user.dict()

--- a/src/auth/app/commands/update_user_role.py
+++ b/src/auth/app/commands/update_user_role.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, replace
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.auth.domain.entities import Role
+from src.shared.app.commands import Command, CommandHandler
+from src.shared.domain.exceptions import NotFoundError
+
+
+@dataclass
+class UpdateUserRoleCommand(Command):
+    user_id: int = 0
+    role: int = Role.VIEWER.value
+
+
+@injectable(lifetime="scoped")
+class UpdateUserRoleCommandHandler(CommandHandler[UpdateUserRoleCommand, dict]):
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def _handle(self, command: UpdateUserRoleCommand) -> dict:
+        user = self.repo.get_by_id(command.user_id)
+        if user is None:
+            raise NotFoundError(f"User with id {command.user_id} not found")
+
+        user = replace(user, role=Role(command.role))
+        user = self.repo.update(user)
+        return user.dict()

--- a/src/auth/app/queries/get_users.py
+++ b/src/auth/app/queries/get_users.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from wireup import injectable
+
+from src.auth.app.repositories import UserRepository
+from src.shared.app.queries import Query, QueryHandler
+from src.shared.domain.exceptions import NotFoundError
+
+
+@dataclass
+class ListUsersQuery(Query):
+    is_active: bool | None = None
+    role: int | None = None
+    limit: int | None = None
+    offset: int | None = None
+
+
+@injectable(lifetime="scoped")
+class ListUsersQueryHandler(QueryHandler[ListUsersQuery, dict]):
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def _handle(self, query: ListUsersQuery) -> dict:
+        filters = {}
+        if query.is_active is not None:
+            filters["is_active"] = query.is_active
+        if query.role is not None:
+            filters["role"] = query.role
+        return self.repo.paginate(limit=query.limit, offset=query.offset, **filters)
+
+
+@dataclass
+class GetUserByIdQuery(Query):
+    user_id: int = 0
+
+
+@injectable(lifetime="scoped")
+class GetUserByIdQueryHandler(QueryHandler[GetUserByIdQuery, dict]):
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def _handle(self, query: GetUserByIdQuery) -> dict:
+        user = self.repo.get_by_id(query.user_id)
+        if user is None:
+            raise NotFoundError(f"User with id {query.user_id} not found")
+        return user.dict()

--- a/src/auth/domain/events.py
+++ b/src/auth/domain/events.py
@@ -30,3 +30,15 @@ class UserLoggedIn(DomainEvent):
             "user_id": self.user_id,
             "username": self.username,
         }
+
+
+@dataclass
+class UserPasswordChanged(DomainEvent):
+    user_id: int = 0
+    username: str = ""
+
+    def _payload(self) -> dict[str, Any]:
+        return {
+            "user_id": self.user_id,
+            "username": self.username,
+        }

--- a/src/auth/domain/permissions.py
+++ b/src/auth/domain/permissions.py
@@ -4,14 +4,44 @@ from src.auth.domain.entities import Role
 
 
 class Permission(StrEnum):
+    PRODUCT_READ = "product:read"
+    PRODUCT_WRITE = "product:write"
+    STOCK_READ = "stock:read"
+    MOVEMENT_WRITE = "movement:write"
+    SALE_READ = "sale:read"
+    SALE_WRITE = "sale:write"
+    SALE_CANCEL = "sale:cancel"
     USER_MANAGE = "user:manage"
 
 
 PERMISSIONS_BY_ROLE: dict[Role, frozenset[Permission]] = {
     Role.ADMIN: frozenset(Permission),
-    Role.MANAGER: frozenset(),
-    Role.OPERATOR: frozenset(),
-    Role.VIEWER: frozenset(),
+    Role.MANAGER: frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.PRODUCT_WRITE,
+            Permission.STOCK_READ,
+            Permission.MOVEMENT_WRITE,
+            Permission.SALE_READ,
+            Permission.SALE_WRITE,
+            Permission.SALE_CANCEL,
+        }
+    ),
+    Role.OPERATOR: frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.STOCK_READ,
+            Permission.SALE_READ,
+            Permission.SALE_WRITE,
+        }
+    ),
+    Role.VIEWER: frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.STOCK_READ,
+            Permission.SALE_READ,
+        }
+    ),
 }
 
 

--- a/src/auth/infra/admin_routes.py
+++ b/src/auth/infra/admin_routes.py
@@ -1,0 +1,165 @@
+from fastapi import APIRouter, Depends
+from wireup import Injected
+
+from src.auth.app.commands.activate_user import (
+    ActivateUserCommand,
+    ActivateUserCommandHandler,
+)
+from src.auth.app.commands.create_user import (
+    CreateUserCommand,
+    CreateUserCommandHandler,
+)
+from src.auth.app.commands.deactivate_user import (
+    DeactivateUserCommand,
+    DeactivateUserCommandHandler,
+)
+from src.auth.app.commands.update_user_role import (
+    UpdateUserRoleCommand,
+    UpdateUserRoleCommandHandler,
+)
+from src.auth.app.queries.get_users import (
+    GetUserByIdQuery,
+    GetUserByIdQueryHandler,
+    ListUsersQuery,
+    ListUsersQueryHandler,
+)
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
+from src.auth.infra.validators import (
+    CreateUserRequest,
+    UpdateUserRoleRequest,
+    UserQueryParams,
+    UserResponse,
+)
+from src.shared.infra.dependencies import get_meta
+from src.shared.infra.validators import (
+    RESPONSES_COMMAND,
+    RESPONSES_LIST,
+    RESPONSES_QUERY,
+    DataResponse,
+    Meta,
+    PaginatedDataResponse,
+)
+
+_perm = [Depends(require_permission(Permission.USER_MANAGE))]
+
+
+class UserAdminRouter:
+    def __init__(self):
+        self.router = APIRouter()
+        self._setup_routes()
+
+    def _setup_routes(self):
+        self.router.get(
+            "",
+            response_model=PaginatedDataResponse[UserResponse],
+            summary="List all users",
+            responses=RESPONSES_LIST,
+            dependencies=_perm,
+        )(self.list_users)
+        self.router.get(
+            "/{user_id}",
+            response_model=DataResponse[UserResponse],
+            summary="Get user by ID",
+            responses=RESPONSES_QUERY,
+            dependencies=_perm,
+        )(self.get_user)
+        self.router.post(
+            "",
+            response_model=DataResponse[UserResponse],
+            summary="Create a new user",
+            responses=RESPONSES_COMMAND,
+            dependencies=_perm,
+        )(self.create_user)
+        self.router.put(
+            "/{user_id}/role",
+            response_model=DataResponse[UserResponse],
+            summary="Update user role",
+            responses=RESPONSES_COMMAND,
+            dependencies=_perm,
+        )(self.update_role)
+        self.router.post(
+            "/{user_id}/activate",
+            response_model=DataResponse[UserResponse],
+            summary="Activate a user",
+            responses=RESPONSES_COMMAND,
+            dependencies=_perm,
+        )(self.activate)
+        self.router.post(
+            "/{user_id}/deactivate",
+            response_model=DataResponse[UserResponse],
+            summary="Deactivate a user",
+            responses=RESPONSES_COMMAND,
+            dependencies=_perm,
+        )(self.deactivate)
+
+    def list_users(
+        self,
+        handler: Injected[ListUsersQueryHandler],
+        query_params: UserQueryParams = Depends(),
+        meta: Meta = Depends(get_meta),
+    ) -> PaginatedDataResponse[UserResponse]:
+        result = handler.handle(
+            ListUsersQuery(**query_params.model_dump(exclude_none=True))
+        )
+        return PaginatedDataResponse(
+            data=[UserResponse.model_validate(u) for u in result["items"]],
+            meta=meta.with_pagination(
+                total=result["total"],
+                limit=result["limit"],
+                offset=result["offset"],
+            ),
+        )
+
+    def get_user(
+        self,
+        handler: Injected[GetUserByIdQueryHandler],
+        user_id: int,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[UserResponse]:
+        result = handler.handle(GetUserByIdQuery(user_id=user_id))
+        return DataResponse(data=UserResponse.model_validate(result), meta=meta)
+
+    def create_user(
+        self,
+        handler: Injected[CreateUserCommandHandler],
+        body: CreateUserRequest,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[UserResponse]:
+        result = handler.handle(
+            CreateUserCommand(
+                username=body.username,
+                email=body.email,
+                password=body.password,
+                role=body.role,
+            )
+        )
+        return DataResponse(data=UserResponse.model_validate(result), meta=meta)
+
+    def update_role(
+        self,
+        handler: Injected[UpdateUserRoleCommandHandler],
+        user_id: int,
+        body: UpdateUserRoleRequest,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[UserResponse]:
+        result = handler.handle(UpdateUserRoleCommand(user_id=user_id, role=body.role))
+        return DataResponse(data=UserResponse.model_validate(result), meta=meta)
+
+    def activate(
+        self,
+        handler: Injected[ActivateUserCommandHandler],
+        user_id: int,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[UserResponse]:
+        result = handler.handle(ActivateUserCommand(user_id=user_id))
+        return DataResponse(data=UserResponse.model_validate(result), meta=meta)
+
+    def deactivate(
+        self,
+        handler: Injected[DeactivateUserCommandHandler],
+        user_id: int,
+        meta: Meta = Depends(get_meta),
+    ) -> DataResponse[UserResponse]:
+        result = handler.handle(DeactivateUserCommand(user_id=user_id))
+        return DataResponse(data=UserResponse.model_validate(result), meta=meta)

--- a/src/auth/infra/container.py
+++ b/src/auth/infra/container.py
@@ -1,6 +1,14 @@
+from src.auth.app.commands.activate_user import ActivateUserCommandHandler
+from src.auth.app.commands.change_password import ChangePasswordCommandHandler
 from src.auth.app.commands.create_user import CreateUserCommandHandler
+from src.auth.app.commands.deactivate_user import DeactivateUserCommandHandler
 from src.auth.app.commands.login import LoginCommandHandler
 from src.auth.app.commands.refresh_token import RefreshTokenCommandHandler
+from src.auth.app.commands.update_user_role import UpdateUserRoleCommandHandler
+from src.auth.app.queries.get_users import (
+    GetUserByIdQueryHandler,
+    ListUsersQueryHandler,
+)
 from src.auth.infra.mappers import UserMapper
 from src.auth.infra.password_hasher import BcryptPasswordHasher
 from src.auth.infra.repositories import SqlAlchemyUserRepository
@@ -14,4 +22,10 @@ INJECTABLES = [
     CreateUserCommandHandler,
     LoginCommandHandler,
     RefreshTokenCommandHandler,
+    ChangePasswordCommandHandler,
+    UpdateUserRoleCommandHandler,
+    DeactivateUserCommandHandler,
+    ActivateUserCommandHandler,
+    ListUsersQueryHandler,
+    GetUserByIdQueryHandler,
 ]

--- a/src/auth/infra/routes.py
+++ b/src/auth/infra/routes.py
@@ -1,6 +1,10 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.app.commands.change_password import (
+    ChangePasswordCommand,
+    ChangePasswordCommandHandler,
+)
 from src.auth.app.commands.login import LoginCommand, LoginCommandHandler
 from src.auth.app.commands.refresh_token import (
     RefreshTokenCommand,
@@ -10,6 +14,7 @@ from src.auth.domain.entities import AuthenticatedUser
 from src.auth.infra.dependencies import get_current_user
 from src.auth.infra.validators import (
     AuthenticatedUserResponse,
+    ChangePasswordRequest,
     LoginRequest,
     RefreshRequest,
     TokenPairResponse,
@@ -47,6 +52,12 @@ class AuthRouter:
             summary="Get the currently authenticated user",
             responses=RESPONSES_QUERY,
         )(self.me)
+        self.router.post(
+            "/change-password",
+            status_code=204,
+            summary="Change the current user's password",
+            responses=RESPONSES_COMMAND,
+        )(self.change_password)
 
     def login(
         self,
@@ -100,4 +111,18 @@ class AuthRouter:
                 permissions=sorted(p.value for p in user.permissions),
             ),
             meta=meta,
+        )
+
+    def change_password(
+        self,
+        handler: Injected[ChangePasswordCommandHandler],
+        body: ChangePasswordRequest,
+        user: AuthenticatedUser = Depends(get_current_user),
+    ) -> None:
+        handler.handle(
+            ChangePasswordCommand(
+                user_id=user.id,
+                current_password=body.current_password,
+                new_password=body.new_password,
+            )
         )

--- a/src/auth/infra/validators.py
+++ b/src/auth/infra/validators.py
@@ -1,5 +1,9 @@
+from datetime import datetime
+
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
+
+from src.shared.infra.validators import QueryParams
 
 
 class LoginRequest(BaseModel):
@@ -14,6 +18,13 @@ class RefreshRequest(BaseModel):
         validation_alias=AliasChoices("refreshToken", "refresh_token"),
         serialization_alias="refreshToken",
     )
+
+
+class ChangePasswordRequest(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    current_password: str = Field(..., min_length=1, max_length=128)
+    new_password: str = Field(..., min_length=8, max_length=128)
 
 
 class TokenPairResponse(BaseModel):
@@ -32,3 +43,47 @@ class AuthenticatedUserResponse(BaseModel):
         description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)"
     )
     permissions: list[str] = Field(default_factory=list)
+
+
+class CreateUserRequest(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    username: str = Field(..., min_length=1, max_length=64)
+    email: str = Field(..., min_length=1, max_length=128)
+    password: str = Field(..., min_length=8, max_length=128)
+    role: int = Field(
+        4,
+        ge=1,
+        le=4,
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)",
+    )
+
+
+class UpdateUserRoleRequest(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    role: int = Field(
+        ...,
+        ge=1,
+        le=4,
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)",
+    )
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+    id: int
+    username: str
+    email: str
+    role: int = Field(
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)"
+    )
+    is_active: bool
+    last_login_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class UserQueryParams(QueryParams):
+    is_active: bool | None = Field(None, description="Filter by active status")
+    role: int | None = Field(None, ge=1, le=4, description="Filter by role")

--- a/src/catalog/product/infra/routes.py
+++ b/src/catalog/product/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.catalog.product.app.commands.create_category import (
     CreateCategoryCommand,
     CreateCategoryCommandHandler,
@@ -160,32 +162,42 @@ class ProductRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.PRODUCT_READ))]
+        _write = [Depends(require_permission(Permission.PRODUCT_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[ProductResponse],
             summary="Save product",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Update product",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete product", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete product",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[ProductResponse],
             summary="Get all products",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Get product by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/sales/infra/routes.py
+++ b/src/sales/infra/routes.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.sales.app.queries.get_payments import (
     GetSalePaymentsQuery,
     GetSalePaymentsQueryHandler,
@@ -40,29 +42,35 @@ class SaleRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.SALE_READ))]
+
         self.router.get(
             "",
             response_model=PaginatedDataResponse[SaleResponse],
             summary="List all sales",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all_sales)
         self.router.get(
             "/{sale_id}",
             response_model=DataResponse[SaleResponse],
             summary="Get sale",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_sale)
         self.router.get(
             "/{sale_id}/items",
             response_model=ListResponse[SaleItemResponse],
             summary="List sale items",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_sale_items)
         self.router.get(
             "/{sale_id}/payments",
             response_model=ListResponse[PaymentResponse],
             summary="List sale payments",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_sale_payments)
 
     def get_all_sales(

--- a/tests/integration/auth/test_require_permission.py
+++ b/tests/integration/auth/test_require_permission.py
@@ -1,0 +1,57 @@
+import pytest
+
+from src.auth.domain.entities import AuthenticatedUser, Role
+from src.auth.domain.exceptions import PermissionDeniedError
+from src.auth.domain.permissions import Permission, permissions_for
+from src.auth.infra.dependencies import require_permission
+
+
+def _make_user(role: Role) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=1,
+        username="testuser",
+        role=role,
+        permissions=permissions_for(role),
+    )
+
+
+def test_admin_passes_all_permissions():
+    admin = _make_user(Role.ADMIN)
+    dep = require_permission(Permission.USER_MANAGE)
+    result = dep(user=admin)
+    assert result.role == Role.ADMIN
+
+
+def test_viewer_blocked_on_write_permissions():
+    viewer = _make_user(Role.VIEWER)
+    dep = require_permission(Permission.PRODUCT_WRITE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=viewer)
+
+
+def test_operator_passes_sale_read():
+    operator = _make_user(Role.OPERATOR)
+    dep = require_permission(Permission.SALE_READ)
+    result = dep(user=operator)
+    assert result.role == Role.OPERATOR
+
+
+def test_operator_blocked_on_sale_cancel():
+    operator = _make_user(Role.OPERATOR)
+    dep = require_permission(Permission.SALE_CANCEL)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=operator)
+
+
+def test_manager_passes_product_write():
+    manager = _make_user(Role.MANAGER)
+    dep = require_permission(Permission.PRODUCT_WRITE)
+    result = dep(user=manager)
+    assert result.role == Role.MANAGER
+
+
+def test_viewer_blocked_on_user_manage():
+    viewer = _make_user(Role.VIEWER)
+    dep = require_permission(Permission.USER_MANAGE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=viewer)

--- a/tests/unit/auth/test_change_password.py
+++ b/tests/unit/auth/test_change_password.py
@@ -1,0 +1,110 @@
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from src.auth.app.commands.change_password import (
+    ChangePasswordCommand,
+    ChangePasswordCommandHandler,
+)
+from src.auth.domain.entities import Role, User
+from src.auth.domain.events import UserPasswordChanged
+from src.auth.domain.exceptions import InvalidCredentialsError
+from src.shared.domain.exceptions import NotFoundError
+
+
+def _make_user(**overrides):
+    defaults = {
+        "id": 1,
+        "username": "testuser",
+        "email": "test@example.com",
+        "password_hash": "hashed_old",
+        "role": Role.ADMIN,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def test_change_password_success():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+    mock_repo.update.return_value = user
+
+    mock_hasher = Mock()
+    mock_hasher.verify.return_value = True
+    mock_hasher.hash.return_value = "hashed_new"
+
+    event_publisher = MagicMock()
+
+    handler = ChangePasswordCommandHandler(mock_repo, mock_hasher, event_publisher)
+    handler.handle(
+        ChangePasswordCommand(
+            user_id=1,
+            current_password="oldpass12",
+            new_password="newpass12",
+        )
+    )
+
+    mock_hasher.verify.assert_called_once_with("oldpass12", "hashed_old")
+    mock_hasher.hash.assert_called_once_with("newpass12")
+    mock_repo.update.assert_called_once()
+    updated_user = mock_repo.update.call_args[0][0]
+    assert updated_user.password_hash == "hashed_new"
+
+    event_publisher.publish.assert_called_once()
+    event = event_publisher.publish.call_args[0][0]
+    assert isinstance(event, UserPasswordChanged)
+    assert event.user_id == 1
+
+
+def test_change_password_wrong_current_raises_invalid_credentials():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+
+    mock_hasher = Mock()
+    mock_hasher.verify.return_value = False
+
+    handler = ChangePasswordCommandHandler(mock_repo, mock_hasher, MagicMock())
+
+    with pytest.raises(InvalidCredentialsError):
+        handler.handle(
+            ChangePasswordCommand(
+                user_id=1,
+                current_password="wrongpass",
+                new_password="newpass12",
+            )
+        )
+
+
+def test_change_password_user_not_found():
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = None
+
+    handler = ChangePasswordCommandHandler(mock_repo, Mock(), MagicMock())
+
+    with pytest.raises(NotFoundError):
+        handler.handle(
+            ChangePasswordCommand(
+                user_id=999,
+                current_password="old",
+                new_password="newpass12",
+            )
+        )
+
+
+def test_change_password_weak_new_password():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+
+    handler = ChangePasswordCommandHandler(mock_repo, Mock(), MagicMock())
+
+    with pytest.raises(ValueError):
+        handler.handle(
+            ChangePasswordCommand(
+                user_id=1,
+                current_password="oldpass12",
+                new_password="short",
+            )
+        )

--- a/tests/unit/auth/test_password_hasher.py
+++ b/tests/unit/auth/test_password_hasher.py
@@ -1,0 +1,20 @@
+from src.auth.infra.password_hasher import BcryptPasswordHasher
+
+
+def test_hash_and_verify_success():
+    hasher = BcryptPasswordHasher()
+    hashed = hasher.hash("mysecretpassword")
+    assert hasher.verify("mysecretpassword", hashed) is True
+
+
+def test_verify_wrong_password_returns_false():
+    hasher = BcryptPasswordHasher()
+    hashed = hasher.hash("correctpassword")
+    assert hasher.verify("wrongpassword", hashed) is False
+
+
+def test_hash_produces_different_results():
+    hasher = BcryptPasswordHasher()
+    hash1 = hasher.hash("samepassword")
+    hash2 = hasher.hash("samepassword")
+    assert hash1 != hash2

--- a/tests/unit/auth/test_permissions.py
+++ b/tests/unit/auth/test_permissions.py
@@ -1,0 +1,56 @@
+from src.auth.domain.entities import Role
+from src.auth.domain.permissions import Permission, permissions_for
+
+
+def test_admin_has_all_permissions():
+    assert permissions_for(Role.ADMIN) == frozenset(Permission)
+
+
+def test_manager_permissions():
+    expected = frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.PRODUCT_WRITE,
+            Permission.STOCK_READ,
+            Permission.MOVEMENT_WRITE,
+            Permission.SALE_READ,
+            Permission.SALE_WRITE,
+            Permission.SALE_CANCEL,
+        }
+    )
+    assert permissions_for(Role.MANAGER) == expected
+
+
+def test_operator_permissions():
+    expected = frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.STOCK_READ,
+            Permission.SALE_READ,
+            Permission.SALE_WRITE,
+        }
+    )
+    assert permissions_for(Role.OPERATOR) == expected
+
+
+def test_viewer_permissions():
+    expected = frozenset(
+        {
+            Permission.PRODUCT_READ,
+            Permission.STOCK_READ,
+            Permission.SALE_READ,
+        }
+    )
+    assert permissions_for(Role.VIEWER) == expected
+
+
+def test_viewer_cannot_write_products():
+    assert Permission.PRODUCT_WRITE not in permissions_for(Role.VIEWER)
+
+
+def test_operator_cannot_cancel_sales():
+    assert Permission.SALE_CANCEL not in permissions_for(Role.OPERATOR)
+
+
+def test_manager_cannot_manage_users():
+    assert Permission.USER_MANAGE not in permissions_for(Role.MANAGER)

--- a/tests/unit/auth/test_user_management.py
+++ b/tests/unit/auth/test_user_management.py
@@ -1,0 +1,116 @@
+from unittest.mock import Mock
+
+import pytest
+
+from src.auth.app.commands.activate_user import (
+    ActivateUserCommand,
+    ActivateUserCommandHandler,
+)
+from src.auth.app.commands.deactivate_user import (
+    DeactivateUserCommand,
+    DeactivateUserCommandHandler,
+)
+from src.auth.app.commands.update_user_role import (
+    UpdateUserRoleCommand,
+    UpdateUserRoleCommandHandler,
+)
+from src.auth.domain.entities import Role, User
+from src.shared.domain.exceptions import NotFoundError
+
+
+def _make_user(**overrides):
+    defaults = {
+        "id": 1,
+        "username": "testuser",
+        "email": "test@example.com",
+        "password_hash": "hashed",
+        "role": Role.VIEWER,
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def test_update_user_role_success():
+    user = _make_user(role=Role.VIEWER)
+    updated = _make_user(role=Role.MANAGER)
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+    mock_repo.update.return_value = updated
+
+    handler = UpdateUserRoleCommandHandler(mock_repo)
+    result = handler.handle(UpdateUserRoleCommand(user_id=1, role=Role.MANAGER.value))
+
+    assert result["role"] == Role.MANAGER
+    mock_repo.update.assert_called_once()
+
+
+def test_update_user_role_not_found():
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = None
+
+    handler = UpdateUserRoleCommandHandler(mock_repo)
+
+    with pytest.raises(NotFoundError):
+        handler.handle(UpdateUserRoleCommand(user_id=999, role=Role.ADMIN.value))
+
+
+def test_update_user_role_invalid_role():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+
+    handler = UpdateUserRoleCommandHandler(mock_repo)
+
+    with pytest.raises(ValueError):
+        handler.handle(UpdateUserRoleCommand(user_id=1, role=99))
+
+
+def test_deactivate_user_success():
+    user = _make_user(is_active=True)
+    deactivated = _make_user(is_active=False)
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+    mock_repo.update.return_value = deactivated
+
+    handler = DeactivateUserCommandHandler(mock_repo)
+    result = handler.handle(DeactivateUserCommand(user_id=1))
+
+    assert result["is_active"] is False
+    updated_arg = mock_repo.update.call_args[0][0]
+    assert updated_arg.is_active is False
+
+
+def test_deactivate_user_not_found():
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = None
+
+    handler = DeactivateUserCommandHandler(mock_repo)
+
+    with pytest.raises(NotFoundError):
+        handler.handle(DeactivateUserCommand(user_id=999))
+
+
+def test_activate_user_success():
+    user = _make_user(is_active=False)
+    activated = _make_user(is_active=True)
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+    mock_repo.update.return_value = activated
+
+    handler = ActivateUserCommandHandler(mock_repo)
+    result = handler.handle(ActivateUserCommand(user_id=1))
+
+    assert result["is_active"] is True
+    updated_arg = mock_repo.update.call_args[0][0]
+    assert updated_arg.is_active is True
+
+
+def test_activate_user_not_found():
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = None
+
+    handler = ActivateUserCommandHandler(mock_repo)
+
+    with pytest.raises(NotFoundError):
+        handler.handle(ActivateUserCommand(user_id=999))

--- a/tests/unit/auth/test_user_queries.py
+++ b/tests/unit/auth/test_user_queries.py
@@ -1,0 +1,81 @@
+from unittest.mock import Mock
+
+import pytest
+
+from src.auth.app.queries.get_users import (
+    GetUserByIdQuery,
+    GetUserByIdQueryHandler,
+    ListUsersQuery,
+    ListUsersQueryHandler,
+)
+from src.auth.domain.entities import Role, User
+from src.shared.domain.exceptions import NotFoundError
+
+
+def _make_user(**overrides):
+    defaults = {
+        "id": 1,
+        "username": "testuser",
+        "email": "test@example.com",
+        "password_hash": "hashed",
+        "role": Role.VIEWER,
+    }
+    defaults.update(overrides)
+    return User(**defaults)
+
+
+def test_list_users_returns_paginated_result():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.paginate.return_value = {
+        "total": 1,
+        "limit": 100,
+        "offset": 0,
+        "items": [user.dict()],
+    }
+
+    handler = ListUsersQueryHandler(mock_repo)
+    result = handler.handle(ListUsersQuery())
+
+    assert result["total"] == 1
+    assert len(result["items"]) == 1
+    mock_repo.paginate.assert_called_once_with(limit=None, offset=None)
+
+
+def test_list_users_passes_filters():
+    mock_repo = Mock()
+    mock_repo.paginate.return_value = {
+        "total": 0,
+        "limit": 10,
+        "offset": 0,
+        "items": [],
+    }
+
+    handler = ListUsersQueryHandler(mock_repo)
+    handler.handle(ListUsersQuery(is_active=True, role=1, limit=10, offset=0))
+
+    mock_repo.paginate.assert_called_once_with(
+        limit=10, offset=0, is_active=True, role=1
+    )
+
+
+def test_get_user_by_id_success():
+    user = _make_user()
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = user
+
+    handler = GetUserByIdQueryHandler(mock_repo)
+    result = handler.handle(GetUserByIdQuery(user_id=1))
+
+    assert result["id"] == 1
+    assert result["username"] == "testuser"
+
+
+def test_get_user_by_id_not_found():
+    mock_repo = Mock()
+    mock_repo.get_by_id.return_value = None
+
+    handler = GetUserByIdQueryHandler(mock_repo)
+
+    with pytest.raises(NotFoundError):
+        handler.handle(GetUserByIdQuery(user_id=999))


### PR DESCRIPTION
## Descripción

  Add role-based permission system with 8 granular permissions (product,
  stock, movement, sale, user) mapped to 4 roles (ADMIN, MANAGER,
  OPERATOR, VIEWER). Implement user admin CRUD at /api/admin/users
  protected by USER_MANAGE permission, change-password endpoint at
  /api/auth/change-password, and enforce permissions on two pilot modules:
  sales routes (SALE_READ) and product routes (PRODUCT_READ/PRODUCT_WRITE).

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [x] Nueva funcionalidad (feature)
- [ ] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
