### PR TITLE
feat: enforce permission coverage on all admin and POS routes

### DIFF
--- a/config/production.py
+++ b/config/production.py
@@ -1,5 +1,18 @@
-from .base import BaseConfig
+from .base import BaseConfig, env
+
+_DEV_JWT_SECRET = "dev-only-change-me"
+_MIN_JWT_SECRET_LENGTH = 32
 
 
 class Config(BaseConfig):
-    pass
+    JWT_SECRET = env.str("JWT_SECRET")
+
+    def __init__(self):
+        if (
+            self.JWT_SECRET == _DEV_JWT_SECRET
+            or len(self.JWT_SECRET) < _MIN_JWT_SECRET_LENGTH
+        ):
+            raise RuntimeError(
+                "JWT_SECRET must be unique and at least "
+                f"{_MIN_JWT_SECRET_LENGTH} characters in production"
+            )

--- a/config/staging.py
+++ b/config/staging.py
@@ -1,5 +1,18 @@
-from .base import BaseConfig
+from .base import BaseConfig, env
+
+_DEV_JWT_SECRET = "dev-only-change-me"
+_MIN_JWT_SECRET_LENGTH = 32
 
 
 class Config(BaseConfig):
-    pass
+    JWT_SECRET = env.str("JWT_SECRET")
+
+    def __init__(self):
+        if (
+            self.JWT_SECRET == _DEV_JWT_SECRET
+            or len(self.JWT_SECRET) < _MIN_JWT_SECRET_LENGTH
+        ):
+            raise RuntimeError(
+                "JWT_SECRET must be unique and at least "
+                f"{_MIN_JWT_SECRET_LENGTH} characters in staging"
+            )

--- a/docs/auth-spec.md
+++ b/docs/auth-spec.md
@@ -1,0 +1,109 @@
+# Auth Spec — Faclab Core
+
+JWT-based authentication with role-based authorization. All admin and POS routes require a valid access token. Login and refresh are public.
+
+## Obtaining a token
+
+```bash
+curl -X POST http://localhost:3000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"ChangeMe123!"}'
+```
+
+Response:
+
+```json
+{
+  "data": {
+    "accessToken": "eyJhbGciOi...",
+    "refreshToken": "eyJhbGciOi...",
+    "tokenType": "Bearer",
+    "expiresIn": 900
+  }
+}
+```
+
+Send the token on every protected request:
+
+```
+Authorization: Bearer <accessToken>
+```
+
+Access tokens expire after `JWT_ACCESS_TTL` seconds (default 900). Refresh via `POST /api/auth/refresh` with `{"refreshToken":"..."}`. The server revalidates the user (role, `is_active`) before reissuing.
+
+## Role × Permission matrix
+
+| Permission | ADMIN | MANAGER | OPERATOR | VIEWER | CASHIER |
+|---|:-:|:-:|:-:|:-:|:-:|
+| `product:read` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `product:write` | ✓ | ✓ | ✓ |   |   |
+| `category:write` | ✓ | ✓ | ✓ |   |   |
+| `uom:write` | ✓ | ✓ | ✓ |   |   |
+| `stock:read` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `movement:write` | ✓ | ✓ | ✓ |   |   |
+| `warehouse:write` | ✓ | ✓ |   |   |   |
+| `location:write` | ✓ | ✓ |   |   |   |
+| `lot:write` | ✓ | ✓ | ✓ |   |   |
+| `serial:write` | ✓ | ✓ | ✓ |   |   |
+| `adjustment:write` | ✓ | ✓ | ✓ |   |   |
+| `transfer:write` | ✓ | ✓ | ✓ |   |   |
+| `alert:read` | ✓ | ✓ | ✓ | ✓ |   |
+| `sale:read` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `sale:write` | ✓ | ✓ | ✓ |   | ✓ |
+| `sale:cancel` | ✓ | ✓ |   |   |   |
+| `purchase:read` | ✓ | ✓ | ✓ | ✓ |   |
+| `purchase:write` | ✓ | ✓ | ✓ |   |   |
+| `purchase:confirm` | ✓ | ✓ |   |   |   |
+| `purchase:receive` | ✓ | ✓ |   |   |   |
+| `customer:read` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `customer:write` | ✓ | ✓ | ✓ |   | ✓ |
+| `supplier:read` | ✓ | ✓ | ✓ | ✓ |   |
+| `supplier:write` | ✓ | ✓ | ✓ |   |   |
+| `pos:operate` | ✓ |   |   |   | ✓ |
+| `refund:approve` | ✓ | ✓ |   |   |   |
+| `report:inventory:read` | ✓ | ✓ | ✓ | ✓ |   |
+| `report:pos:read` | ✓ | ✓ |   | ✓ | ✓ |
+| `user:manage` | ✓ |   |   |   |   |
+
+Role numeric codes (persisted in DB):
+
+| Code | Role |
+|---|---|
+| 1 | ADMIN |
+| 2 | MANAGER |
+| 3 | OPERATOR |
+| 4 | VIEWER |
+| 5 | CASHIER |
+
+## Protecting a new route
+
+```python
+from fastapi import Depends
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
+
+def _setup_routes(self):
+    _read = [Depends(require_permission(Permission.PRODUCT_READ))]
+    _write = [Depends(require_permission(Permission.PRODUCT_WRITE))]
+
+    self.router.get("", ..., dependencies=_read)(self.list)
+    self.router.post("", ..., dependencies=_write)(self.create)
+```
+
+Route-level `dependencies=[...]` runs before the handler. If the user is unauthenticated, the dependency raises `PermissionDeniedError("authentication required")` → 403. If the user lacks the permission, it raises `PermissionDeniedError("missing permissions: [...]")` → 403.
+
+## Adding a new permission
+
+1. Add the verb to `Permission` (StrEnum) in `src/auth/domain/permissions.py` under the right module comment.
+2. Add it to the role mappings in `PERMISSIONS_BY_ROLE` (or to `_ALL_READS` / `_OPERATOR_PERMS` / `_CASHIER_PERMS` if it fits an existing bundle). `ADMIN` and `MANAGER` receive it automatically (MANAGER via `frozenset(Permission) - {excluded}`).
+3. Add unit tests in `tests/unit/auth/test_permissions.py` covering which roles do and do not get the new permission.
+4. Apply it to the relevant routers via `Depends(require_permission(...))`.
+
+Tokens carry only `role`; permissions are re-derived on every request via `permissions_for(role)`. You do not need to reissue tokens when mapping changes.
+
+## Production checklist
+
+- `JWT_SECRET` must be set (config `production.py` raises on missing / short secret).
+- Seed the first admin: `AUTH_SEED_USERNAME=... AUTH_SEED_EMAIL=... AUTH_SEED_PASSWORD=... python -m src.auth.seed`
+- Rotate `JWT_SECRET` invalidates all active tokens (users must log in again).
+- Rate limiting on `/api/auth/login` is NOT implemented — put it at the reverse proxy if exposed publicly.

--- a/main.py
+++ b/main.py
@@ -81,6 +81,19 @@ def _custom_openapi() -> dict:
         tags=_docs.openapi_tags,
     )
     schema["x-tagGroups"] = _docs.tag_groups
+    schema.setdefault("components", {})["securitySchemes"] = {
+        "bearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    }
+    schema["security"] = [{"bearerAuth": []}]
+    for public_path in ("/api/auth/login", "/api/auth/refresh"):
+        path_item = schema.get("paths", {}).get(public_path, {})
+        for operation in path_item.values():
+            if isinstance(operation, dict):
+                operation["security"] = []
     app.openapi_schema = schema
     return schema
 

--- a/src/auth/domain/entities.py
+++ b/src/auth/domain/entities.py
@@ -10,6 +10,7 @@ class Role(IntEnum):
     MANAGER = 2
     OPERATOR = 3
     VIEWER = 4
+    CASHIER = 5
 
 
 @dataclass

--- a/src/auth/domain/permissions.py
+++ b/src/auth/domain/permissions.py
@@ -4,44 +4,115 @@ from src.auth.domain.entities import Role
 
 
 class Permission(StrEnum):
+    # Catalog
     PRODUCT_READ = "product:read"
     PRODUCT_WRITE = "product:write"
+    CATEGORY_WRITE = "category:write"
+    UOM_WRITE = "uom:write"
+
+    # Inventory
     STOCK_READ = "stock:read"
     MOVEMENT_WRITE = "movement:write"
+    WAREHOUSE_WRITE = "warehouse:write"
+    LOCATION_WRITE = "location:write"
+    LOT_WRITE = "lot:write"
+    SERIAL_WRITE = "serial:write"
+    ADJUSTMENT_WRITE = "adjustment:write"
+    TRANSFER_WRITE = "transfer:write"
+    ALERT_READ = "alert:read"
+
+    # Sales
     SALE_READ = "sale:read"
     SALE_WRITE = "sale:write"
     SALE_CANCEL = "sale:cancel"
+
+    # Purchasing
+    PURCHASE_READ = "purchase:read"
+    PURCHASE_WRITE = "purchase:write"
+    PURCHASE_CONFIRM = "purchase:confirm"
+    PURCHASE_RECEIVE = "purchase:receive"
+
+    # Partners
+    CUSTOMER_READ = "customer:read"
+    CUSTOMER_WRITE = "customer:write"
+    SUPPLIER_READ = "supplier:read"
+    SUPPLIER_WRITE = "supplier:write"
+
+    # POS
+    POS_OPERATE = "pos:operate"
+    REFUND_APPROVE = "refund:approve"
+
+    # Reports
+    REPORT_INVENTORY_READ = "report:inventory:read"
+    REPORT_POS_READ = "report:pos:read"
+
+    # Admin
     USER_MANAGE = "user:manage"
+
+
+_ALL_READS = frozenset(
+    {
+        Permission.PRODUCT_READ,
+        Permission.STOCK_READ,
+        Permission.SALE_READ,
+        Permission.PURCHASE_READ,
+        Permission.CUSTOMER_READ,
+        Permission.SUPPLIER_READ,
+        Permission.ALERT_READ,
+        Permission.REPORT_INVENTORY_READ,
+        Permission.REPORT_POS_READ,
+    }
+)
+
+_MANAGER_PERMS = frozenset(Permission) - frozenset(
+    {Permission.USER_MANAGE, Permission.POS_OPERATE}
+)
+
+_OPERATOR_PERMS = frozenset(
+    {
+        Permission.PRODUCT_READ,
+        Permission.PRODUCT_WRITE,
+        Permission.CATEGORY_WRITE,
+        Permission.UOM_WRITE,
+        Permission.STOCK_READ,
+        Permission.MOVEMENT_WRITE,
+        Permission.LOT_WRITE,
+        Permission.SERIAL_WRITE,
+        Permission.ADJUSTMENT_WRITE,
+        Permission.TRANSFER_WRITE,
+        Permission.ALERT_READ,
+        Permission.SALE_READ,
+        Permission.SALE_WRITE,
+        Permission.PURCHASE_READ,
+        Permission.PURCHASE_WRITE,
+        Permission.CUSTOMER_READ,
+        Permission.CUSTOMER_WRITE,
+        Permission.SUPPLIER_READ,
+        Permission.SUPPLIER_WRITE,
+        Permission.REPORT_INVENTORY_READ,
+    }
+)
+
+_CASHIER_PERMS = frozenset(
+    {
+        Permission.POS_OPERATE,
+        Permission.SALE_READ,
+        Permission.SALE_WRITE,
+        Permission.PRODUCT_READ,
+        Permission.STOCK_READ,
+        Permission.CUSTOMER_READ,
+        Permission.CUSTOMER_WRITE,
+        Permission.REPORT_POS_READ,
+    }
+)
 
 
 PERMISSIONS_BY_ROLE: dict[Role, frozenset[Permission]] = {
     Role.ADMIN: frozenset(Permission),
-    Role.MANAGER: frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.PRODUCT_WRITE,
-            Permission.STOCK_READ,
-            Permission.MOVEMENT_WRITE,
-            Permission.SALE_READ,
-            Permission.SALE_WRITE,
-            Permission.SALE_CANCEL,
-        }
-    ),
-    Role.OPERATOR: frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.STOCK_READ,
-            Permission.SALE_READ,
-            Permission.SALE_WRITE,
-        }
-    ),
-    Role.VIEWER: frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.STOCK_READ,
-            Permission.SALE_READ,
-        }
-    ),
+    Role.MANAGER: _MANAGER_PERMS,
+    Role.OPERATOR: _OPERATOR_PERMS,
+    Role.VIEWER: _ALL_READS,
+    Role.CASHIER: _CASHIER_PERMS,
 }
 
 

--- a/src/catalog/product/infra/routes.py
+++ b/src/catalog/product/infra/routes.py
@@ -66,32 +66,42 @@ class CategoryRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.PRODUCT_READ))]
+        _write = [Depends(require_permission(Permission.CATEGORY_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[CategoryResponse],
             summary="Save category",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[CategoryResponse],
             summary="Update category",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete category", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete category",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[CategoryResponse],
             summary="Get all categories",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CategoryResponse],
             summary="Get category by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/catalog/uom/infra/routes.py
+++ b/src/catalog/uom/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.catalog.uom.app.commands.create import (
     CreateUnitOfMeasureCommand,
     CreateUnitOfMeasureCommandHandler,
@@ -42,32 +44,42 @@ class UnitOfMeasureRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.PRODUCT_READ))]
+        _write = [Depends(require_permission(Permission.UOM_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Create unit of measure",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Update unit of measure",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete unit of measure", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete unit of measure",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[UnitOfMeasureResponse],
             summary="Get all units of measure",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[UnitOfMeasureResponse],
             summary="Get unit of measure by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/customers/infra/routes.py
+++ b/src/customers/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, Query
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.customers.app.commands.customer import (
     ActivateCustomerCommand,
     ActivateCustomerCommandHandler,
@@ -62,62 +64,77 @@ class CustomerRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.CUSTOMER_READ))]
+        _write = [Depends(require_permission(Permission.CUSTOMER_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[CustomerResponse],
             summary="Create customer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Update customer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete customer", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete customer",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[CustomerResponse],
             summary="Get all customers",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.get(
             "/search/by-tax-id",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer by tax ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_tax_id)
         self.router.post(
             "/{id}/activate",
             response_model=DataResponse[CustomerResponse],
             summary="Activate customer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.activate)
         self.router.post(
             "/{id}/deactivate",
             response_model=DataResponse[CustomerResponse],
             summary="Deactivate customer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.deactivate)
         self.router.post(
             "/{customer_id}/contacts",
             response_model=DataResponse[CustomerContactResponse],
             summary="Create customer contact",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create_contact)
         self.router.get(
             "/{customer_id}/contacts",
             response_model=ListResponse[CustomerContactResponse],
             summary="Get customer contacts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_customer_contacts)
 
     def create(
@@ -250,20 +267,28 @@ class CustomerContactRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.CUSTOMER_READ))]
+        _write = [Depends(require_permission(Permission.CUSTOMER_WRITE))]
+
         self.router.put(
             "/{id}",
             response_model=DataResponse[CustomerContactResponse],
             summary="Update customer contact",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete customer contact", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete customer contact",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerContactResponse],
             summary="Get customer contact by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def update(

--- a/src/inventory/adjustment/infra/routes.py
+++ b/src/inventory/adjustment/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.adjustment.app.commands.adjustment import (
     AddAdjustmentItemCommand,
     AddAdjustmentItemCommandHandler,
@@ -55,59 +57,71 @@ class AdjustmentRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.ADJUSTMENT_WRITE))]
+
         self.router.get(
             "",
             response_model=PaginatedDataResponse[AdjustmentResponse],
             summary="Get all adjustments",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.post(
             "",
             response_model=DataResponse[AdjustmentResponse],
             summary="Create adjustment",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.get(
             "/{id}",
             response_model=DataResponse[AdjustmentResponse],
             summary="Get adjustment by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.put(
             "/{id}",
             response_model=DataResponse[AdjustmentResponse],
             summary="Update adjustment",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
             "/{id}",
             status_code=204,
             summary="Delete adjustment",
             responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.post(
             "/{id}/confirm",
             response_model=DataResponse[AdjustmentResponse],
             summary="Confirm adjustment",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.confirm)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[AdjustmentResponse],
             summary="Cancel adjustment",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.cancel)
         self.router.post(
             "/{id}/items",
             response_model=DataResponse[AdjustmentItemResponse],
             summary="Add item to adjustment",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.add_item)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[AdjustmentItemResponse],
             summary="Get adjustment items",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_items)
 
     def get_all(
@@ -234,17 +248,21 @@ class AdjustmentItemRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _write = [Depends(require_permission(Permission.ADJUSTMENT_WRITE))]
+
         self.router.put(
             "/{id}",
             response_model=DataResponse[AdjustmentItemResponse],
             summary="Update adjustment item",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
             "/{id}",
             status_code=204,
             summary="Remove adjustment item",
             responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.remove)
 
     def update(

--- a/src/inventory/alert/infra/routes.py
+++ b/src/inventory/alert/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.alert.app.queries.alerts import (
     GetExpiringLotsAlertsQuery,
     GetExpiringLotsAlertsQueryHandler,
@@ -26,29 +28,35 @@ class AlertRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.ALERT_READ))]
+
         self.router.get(
             "/low-stock",
             response_model=ListResponse[StockAlertResponse],
             summary="Get low stock alerts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.low_stock)
         self.router.get(
             "/out-of-stock",
             response_model=ListResponse[StockAlertResponse],
             summary="Get out of stock alerts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.out_of_stock)
         self.router.get(
             "/reorder-point",
             response_model=ListResponse[StockAlertResponse],
             summary="Get reorder point alerts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.reorder_point)
         self.router.get(
             "/expiring-lots",
             response_model=ListResponse[StockAlertResponse],
             summary="Get expiring lots alerts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.expiring_lots)
 
     def low_stock(

--- a/src/inventory/location/infra/routes.py
+++ b/src/inventory/location/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.location.app.commands.create import (
     CreateLocationCommand,
     CreateLocationCommandHandler,
@@ -38,32 +40,42 @@ class LocationRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.LOCATION_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[LocationResponse],
             summary="Create location",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[LocationResponse],
             summary="Update location",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete location", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete location",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=ListResponse[LocationResponse],
             summary="Get all locations",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[LocationResponse],
             summary="Get location by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/inventory/lot/infra/routes.py
+++ b/src/inventory/lot/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.lot.app.commands.lot import (
     CreateLotCommand,
     CreateLotCommandHandler,
@@ -36,29 +38,36 @@ class LotRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.LOT_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[LotResponse],
             summary="Create lot",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[LotResponse],
             summary="Update lot",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[LotResponse],
             summary="Get lots",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[LotResponse],
             summary="Get lot by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/inventory/movement/infra/routes.py
+++ b/src/inventory/movement/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.movement.app.commands.movement import (
     CreateMovementCommand,
     CreateMovementCommandHandler,
@@ -31,17 +33,22 @@ class MovementRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.MOVEMENT_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[MovementResponse],
             summary="Save movement",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[MovementResponse],
             summary="Get all movements",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
 
     def create(

--- a/src/inventory/serial/infra/routes.py
+++ b/src/inventory/serial/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.serial.app.commands.serial import (
     CreateSerialNumberCommand,
     CreateSerialNumberCommandHandler,
@@ -36,29 +38,36 @@ class SerialRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.SERIAL_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[SerialNumberResponse],
             summary="Create serial number",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[SerialNumberResponse],
             summary="Get serial numbers",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SerialNumberResponse],
             summary="Get serial number by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.put(
             "/{id}/status",
             response_model=DataResponse[SerialNumberResponse],
             summary="Update serial number status",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update_status)
 
     def create(

--- a/src/inventory/stock/infra/routes.py
+++ b/src/inventory/stock/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.stock.app.queries.stock import (
     GetAllStocksQuery,
     GetAllStocksQueryHandler,
@@ -17,11 +19,14 @@ class StockRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+
         self.router.get(
             "",
             response_model=PaginatedDataResponse[StockResponse],
             summary="Get all stocks",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
 
     def get_all(

--- a/src/inventory/transfer/infra/routes.py
+++ b/src/inventory/transfer/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.transfer.app.commands.transfer import (
     AddTransferItemCommand,
     AddTransferItemCommandHandler,
@@ -57,65 +59,78 @@ class TransferRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.TRANSFER_WRITE))]
+
         self.router.get(
             "",
             response_model=PaginatedDataResponse[TransferResponse],
             summary="Get all transfers",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.post(
             "",
             response_model=DataResponse[TransferResponse],
             summary="Create transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.get(
             "/{id}",
             response_model=DataResponse[TransferResponse],
             summary="Get transfer by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.put(
             "/{id}",
             response_model=DataResponse[TransferResponse],
             summary="Update transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
             "/{id}",
             status_code=204,
             summary="Delete transfer",
             responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.post(
             "/{id}/confirm",
             response_model=DataResponse[TransferResponse],
             summary="Confirm transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.confirm)
         self.router.post(
             "/{id}/receive",
             response_model=DataResponse[TransferResponse],
             summary="Receive transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.receive)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[TransferResponse],
             summary="Cancel transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.cancel)
         self.router.post(
             "/{id}/items",
             response_model=DataResponse[TransferItemResponse],
             summary="Add item to transfer",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.add_item)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[TransferItemResponse],
             summary="Get transfer items",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_items)
 
     def get_all(
@@ -250,17 +265,21 @@ class TransferItemRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _write = [Depends(require_permission(Permission.TRANSFER_WRITE))]
+
         self.router.put(
             "/{id}",
             response_model=DataResponse[TransferItemResponse],
             summary="Update transfer item",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
             "/{id}",
             status_code=204,
             summary="Remove transfer item",
             responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.remove)
 
     def update(

--- a/src/inventory/warehouse/infra/routes.py
+++ b/src/inventory/warehouse/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.inventory.warehouse.app.commands.create import (
     CreateWarehouseCommand,
     CreateWarehouseCommandHandler,
@@ -38,32 +40,42 @@ class WarehouseRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.STOCK_READ))]
+        _write = [Depends(require_permission(Permission.WAREHOUSE_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[WarehouseResponse],
             summary="Create warehouse",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[WarehouseResponse],
             summary="Update warehouse",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete warehouse", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete warehouse",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=ListResponse[WarehouseResponse],
             summary="Get all warehouses",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[WarehouseResponse],
             summary="Get warehouse by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/pos/cash/infra/routes.py
+++ b/src/pos/cash/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, status
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.pos.cash.app.commands.register_cash_movement import (
     RegisterCashMovementCommand,
     RegisterCashMovementCommandHandler,
@@ -36,24 +38,29 @@ class POSCashRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _pos = [Depends(require_permission(Permission.POS_OPERATE))]
+
         self.router.post(
             "/{shift_id}/cash-movements",
             response_model=DataResponse[CashMovementResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Register cash movement",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.register_cash_movement)
         self.router.get(
             "/{shift_id}/cash-movements",
             response_model=PaginatedDataResponse[CashMovementResponse],
             summary="List cash movements for a shift",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.get_cash_movements)
         self.router.get(
             "/{shift_id}/cash-summary",
             response_model=DataResponse[CashSummaryResponse],
             summary="Get cash summary for a shift",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.get_cash_summary)
 
     def register_cash_movement(

--- a/src/pos/infra/routes.py
+++ b/src/pos/infra/routes.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter, Depends, Query
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.catalog.product.app.queries.get_products import (
     GetAllProductsQuery,
     GetAllProductsQueryHandler,
@@ -43,23 +45,28 @@ class POSProductRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.PRODUCT_READ))]
+
         self.router.get(
             "",
             response_model=ListResponse[ProductResponse],
             summary="List products",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/search",
             response_model=ListResponse[ProductResponse],
             summary="Search products by SKU, barcode or name",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.search)
         self.router.get(
             "/{id}",
             response_model=DataResponse[ProductResponse],
             summary="Get product",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def get_all(
@@ -103,30 +110,37 @@ class POSCustomerRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.CUSTOMER_READ))]
+        _write = [Depends(require_permission(Permission.CUSTOMER_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[CustomerResponse],
             summary="Quick create customer",
             status_code=201,
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.get(
             "",
             response_model=ListResponse[CustomerResponse],
             summary="List customers",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/search/by-tax-id",
             response_model=DataResponse[CustomerResponse],
             summary="Search customer by tax ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_tax_id)
         self.router.get(
             "/{id}",
             response_model=DataResponse[CustomerResponse],
             summary="Get customer",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def create(

--- a/src/pos/refund/infra/routes.py
+++ b/src/pos/refund/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends, status
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.pos.refund.app.commands.cancel_refund import (
     CancelRefundCommand,
     CancelRefundCommandHandler,
@@ -43,36 +45,44 @@ class POSRefundRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _pos = [Depends(require_permission(Permission.POS_OPERATE))]
+        _approve = [Depends(require_permission(Permission.REFUND_APPROVE))]
+
         self.router.post(
             "",
             response_model=DataResponse[RefundDetailResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Create refund",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.create_refund)
         self.router.post(
             "/{refund_id}/process",
             response_model=DataResponse[RefundDetailResponse],
             summary="Process refund",
             responses=RESPONSES_COMMAND,
+            dependencies=_approve,
         )(self.process_refund)
         self.router.post(
             "/{refund_id}/cancel",
             response_model=DataResponse[RefundResponse],
             summary="Cancel refund",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.cancel_refund)
         self.router.get(
             "/{refund_id}",
             response_model=DataResponse[RefundDetailResponse],
             summary="Get refund",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.get_refund)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[RefundResponse],
             summary="List refunds",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.list_refunds)
 
     def create_refund(

--- a/src/pos/reports/infra/routes.py
+++ b/src/pos/reports/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.pos.reports.app.queries.by_payment_method import (
     GetSalesByPaymentMethodQuery,
     GetSalesByPaymentMethodQueryHandler,
@@ -37,29 +39,35 @@ class POSReportRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.REPORT_POS_READ))]
+
         self.router.get(
             "/x-report",
             response_model=DataResponse[XReportResponse],
             summary="X-Report (shift sales summary)",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.x_report)
         self.router.get(
             "/z-report",
             response_model=DataResponse[ZReportResponse],
             summary="Z-Report (shift closing report)",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.z_report)
         self.router.get(
             "/daily",
             response_model=DataResponse[DailySummaryResponse],
             summary="Daily sales summary",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.daily_summary)
         self.router.get(
             "/by-payment-method",
             response_model=ListResponse[PaymentMethodSummaryResponse],
             summary="Sales by payment method",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.by_payment_method)
 
     def x_report(

--- a/src/pos/sales/infra/routes.py
+++ b/src/pos/sales/infra/routes.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter, Depends, status
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.pos.sales.app.commands.apply_discount import (
     ApplySaleDiscountCommand,
     ApplySaleDiscountCommandHandler,
@@ -104,12 +106,15 @@ class POSSaleRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _pos = [Depends(require_permission(Permission.POS_OPERATE))]
+
         self.router.post(
             "",
             response_model=DataResponse[SaleResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Create sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.create_sale)
         self.router.post(
             "/quick",
@@ -117,18 +122,21 @@ class POSSaleRouter:
             status_code=status.HTTP_201_CREATED,
             summary="Quick sale (checkout in one request)",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.quick_sale)
         self.router.get(
             "/parked",
             response_model=ListResponse[SaleResponse],
             summary="List parked sales",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.get_parked_sales)
         self.router.get(
             "/{sale_id}",
             response_model=DataResponse[SaleResponse],
             summary="Get sale",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.get_sale)
         self.router.post(
             "/{sale_id}/items",
@@ -136,53 +144,62 @@ class POSSaleRouter:
             status_code=status.HTTP_201_CREATED,
             summary="Add item to sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.add_sale_item)
         self.router.get(
             "/{sale_id}/items",
             response_model=ListResponse[SaleItemResponse],
             summary="List sale items",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.get_sale_items)
         self.router.put(
             "/{sale_id}/items/{item_id}",
             response_model=DataResponse[SaleItemResponse],
             summary="Update sale item",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.update_sale_item)
         self.router.delete(
             "/{sale_id}/items/{item_id}",
             summary="Remove item from sale",
             responses=RESPONSES_DELETE,
+            dependencies=_pos,
         )(self.remove_sale_item)
         self.router.post(
             "/{sale_id}/confirm",
             response_model=DataResponse[SaleResponse],
             summary="Confirm sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.confirm_sale)
         self.router.post(
             "/{sale_id}/cancel",
             response_model=DataResponse[SaleResponse],
             summary="Cancel sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.cancel_sale)
         self.router.post(
             "/{sale_id}/park",
             response_model=DataResponse[SaleResponse],
             summary="Park sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.park_sale)
         self.router.post(
             "/{sale_id}/resume",
             response_model=DataResponse[SaleResponse],
             summary="Resume parked sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.resume_sale)
         self.router.post(
             "/{sale_id}/discount",
             response_model=DataResponse[SaleResponse],
             summary="Apply discount to sale",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.apply_discount)
         self.router.post(
             "/{sale_id}/payments",
@@ -190,24 +207,28 @@ class POSSaleRouter:
             status_code=status.HTTP_201_CREATED,
             summary="Register payment",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.register_payment)
         self.router.get(
             "/{sale_id}/payments",
             response_model=ListResponse[PaymentResponse],
             summary="List sale payments",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.get_sale_payments)
         self.router.put(
             "/{sale_id}/items/{item_id}/price",
             response_model=DataResponse[SaleItemResponse],
             summary="Override item price",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.override_item_price)
         self.router.get(
             "/{sale_id}/receipt",
             response_model=DataResponse[ReceiptResponse],
             summary="Generate receipt",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.generate_receipt)
 
     def create_sale(

--- a/src/pos/shift/infra/routes.py
+++ b/src/pos/shift/infra/routes.py
@@ -3,6 +3,8 @@
 from fastapi import APIRouter, Depends, status
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.pos.shift.app.commands.close_shift import (
     CloseShiftCommand,
     CloseShiftCommandHandler,
@@ -42,36 +44,43 @@ class POSShiftRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _pos = [Depends(require_permission(Permission.POS_OPERATE))]
+
         self.router.post(
             "/open",
             response_model=DataResponse[ShiftResponse],
             status_code=status.HTTP_201_CREATED,
             summary="Open shift",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.open_shift)
         self.router.post(
             "/{shift_id}/close",
             response_model=DataResponse[ShiftResponse],
             summary="Close shift",
             responses=RESPONSES_COMMAND,
+            dependencies=_pos,
         )(self.close_shift)
         self.router.get(
             "/active",
             response_model=DataResponse[ShiftResponse | None],
             summary="Get active shift",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.get_active_shift)
         self.router.get(
             "/{shift_id}",
             response_model=DataResponse[ShiftResponse],
             summary="Get shift by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_pos,
         )(self.get_shift)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[ShiftResponse],
             summary="List all shifts",
             responses=RESPONSES_LIST,
+            dependencies=_pos,
         )(self.get_all_shifts)
 
     def open_shift(

--- a/src/purchasing/infra/routes.py
+++ b/src/purchasing/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.purchasing.app.commands.purchase_order import (
     CancelPurchaseOrderCommand,
     CancelPurchaseOrderCommandHandler,
@@ -69,62 +71,79 @@ class PurchaseOrderRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.PURCHASE_READ))]
+        _write = [Depends(require_permission(Permission.PURCHASE_WRITE))]
+        _confirm = [Depends(require_permission(Permission.PURCHASE_CONFIRM))]
+        _receive = [Depends(require_permission(Permission.PURCHASE_RECEIVE))]
+
         self.router.post(
             "",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Create purchase order",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Update purchase order",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete purchase order", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete purchase order",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[PurchaseOrderResponse],
             summary="Get all purchase orders",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Get purchase order by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.post(
             "/{id}/send",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Send purchase order to supplier",
             responses=RESPONSES_COMMAND,
+            dependencies=_confirm,
         )(self.send)
         self.router.post(
             "/{id}/cancel",
             response_model=DataResponse[PurchaseOrderResponse],
             summary="Cancel purchase order",
             responses=RESPONSES_COMMAND,
+            dependencies=_confirm,
         )(self.cancel)
         self.router.post(
             "/{id}/receive",
             response_model=DataResponse[PurchaseReceiptResponse],
             summary="Receive goods for purchase order",
             responses=RESPONSES_COMMAND,
+            dependencies=_receive,
         )(self.receive)
         self.router.get(
             "/{id}/items",
             response_model=ListResponse[PurchaseOrderItemResponse],
             summary="Get items for a purchase order",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_items)
         self.router.get(
             "/{id}/receipts",
             response_model=ListResponse[PurchaseReceiptResponse],
             summary="Get receipts for a purchase order",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_receipts)
 
     def create(
@@ -282,20 +301,27 @@ class POItemRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _write = [Depends(require_permission(Permission.PURCHASE_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[PurchaseOrderItemResponse],
             summary="Add item to purchase order",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.add)
         self.router.put(
             "/{id}",
             response_model=DataResponse[PurchaseOrderItemResponse],
             summary="Update purchase order item",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Remove purchase order item", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Remove purchase order item",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.remove)
 
     def add(

--- a/src/reports/inventory/infra/routes.py
+++ b/src/reports/inventory/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.reports.inventory.app.queries.movement_history import (
     GetMovementHistoryReportQuery,
     GetMovementHistoryReportQueryHandler,
@@ -44,29 +46,35 @@ class ReportRouter:
         self._setup_routes()
 
     def _setup_routes(self):
+        _read = [Depends(require_permission(Permission.REPORT_INVENTORY_READ))]
+
         self.router.get(
             "/valuation",
             response_model=DataResponse[InventoryValuationResponse],
             summary="Inventory valuation report",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.valuation)
         self.router.get(
             "/rotation",
             response_model=ListResponse[ProductRotationResponse],
             summary="Product rotation report",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.rotation)
         self.router.get(
             "/movements",
             response_model=PaginatedDataResponse[MovementHistoryItemResponse],
             summary="Movement history report",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.movement_history)
         self.router.get(
             "/summary",
             response_model=ListResponse[WarehouseSummaryResponse],
             summary="Warehouse summary report",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.warehouse_summary)
 
     def valuation(

--- a/src/suppliers/infra/routes.py
+++ b/src/suppliers/infra/routes.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter, Depends
 from wireup import Injected
 
+from src.auth.domain.permissions import Permission
+from src.auth.infra.dependencies import require_permission
 from src.shared.infra.dependencies import get_meta
 from src.shared.infra.validators import (
     RESPONSES_COMMAND,
@@ -78,68 +80,84 @@ class SupplierRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.SUPPLIER_READ))]
+        _write = [Depends(require_permission(Permission.SUPPLIER_WRITE))]
+
         self.router.post(
             "",
             response_model=DataResponse[SupplierResponse],
             summary="Create supplier",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create)
         self.router.put(
             "/{id}",
             response_model=DataResponse[SupplierResponse],
             summary="Update supplier",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete supplier", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete supplier",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "",
             response_model=PaginatedDataResponse[SupplierResponse],
             summary="Get all suppliers",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_all)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierResponse],
             summary="Get supplier by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.post(
             "/{id}/activate",
             response_model=DataResponse[SupplierResponse],
             summary="Activate supplier",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.activate)
         self.router.post(
             "/{id}/deactivate",
             response_model=DataResponse[SupplierResponse],
             summary="Deactivate supplier",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.deactivate)
         self.router.post(
             "/{supplier_id}/contacts",
             response_model=DataResponse[SupplierContactResponse],
             summary="Create supplier contact",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create_contact)
         self.router.get(
             "/{supplier_id}/contacts",
             response_model=ListResponse[SupplierContactResponse],
             summary="Get supplier contacts",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_supplier_contacts)
         self.router.post(
             "/{supplier_id}/products",
             response_model=DataResponse[SupplierProductResponse],
             summary="Add product to supplier catalog",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.create_supplier_product)
         self.router.get(
             "/{supplier_id}/products",
             response_model=ListResponse[SupplierProductResponse],
             summary="Get supplier products",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_supplier_products)
 
     def create(
@@ -295,20 +313,28 @@ class SupplierContactRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.SUPPLIER_READ))]
+        _write = [Depends(require_permission(Permission.SUPPLIER_WRITE))]
+
         self.router.put(
             "/{id}",
             response_model=DataResponse[SupplierContactResponse],
             summary="Update supplier contact",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete supplier contact", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete supplier contact",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierContactResponse],
             summary="Get supplier contact by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
 
     def update(
@@ -354,26 +380,35 @@ class SupplierProductRouter:
 
     def _setup_routes(self):
         """Sets up all the routes for the router."""
+        _read = [Depends(require_permission(Permission.SUPPLIER_READ))]
+        _write = [Depends(require_permission(Permission.SUPPLIER_WRITE))]
+
         self.router.put(
             "/{id}",
             response_model=DataResponse[SupplierProductResponse],
             summary="Update supplier product",
             responses=RESPONSES_COMMAND,
+            dependencies=_write,
         )(self.update)
         self.router.delete(
-            "/{id}", summary="Delete supplier product", responses=RESPONSES_DELETE
+            "/{id}",
+            summary="Delete supplier product",
+            responses=RESPONSES_DELETE,
+            dependencies=_write,
         )(self.delete)
         self.router.get(
             "/{id}",
             response_model=DataResponse[SupplierProductResponse],
             summary="Get supplier product by ID",
             responses=RESPONSES_QUERY,
+            dependencies=_read,
         )(self.get_by_id)
         self.router.get(
             "/by-product/{product_id}",
             response_model=ListResponse[SupplierProductResponse],
             summary="Get all suppliers for a product",
             responses=RESPONSES_LIST,
+            dependencies=_read,
         )(self.get_by_product)
 
     def update(

--- a/tests/integration/auth/test_all_admin_routes_require_auth.py
+++ b/tests/integration/auth/test_all_admin_routes_require_auth.py
@@ -1,0 +1,96 @@
+"""Guard test: every /api/admin route must carry a require_permission dependency.
+
+This fails if a new admin router is added without authorization coverage.
+"""
+
+from fastapi import APIRouter, FastAPI
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute
+
+from src.auth.infra.admin_routes import UserAdminRouter
+from src.auth.infra.dependencies import get_current_user
+from src.catalog.product.infra.routes import CategoryRouter, ProductRouter
+from src.catalog.uom.infra.routes import UnitOfMeasureRouter
+from src.customers.infra.routes import CustomerContactRouter, CustomerRouter
+from src.inventory.adjustment.infra.routes import AdjustmentItemRouter, AdjustmentRouter
+from src.inventory.alert.infra.routes import AlertRouter
+from src.inventory.location.infra.routes import LocationRouter
+from src.inventory.lot.infra.routes import LotRouter
+from src.inventory.movement.infra.routes import MovementRouter
+from src.inventory.serial.infra.routes import SerialRouter
+from src.inventory.stock.infra.routes import StockRouter
+from src.inventory.transfer.infra.routes import TransferItemRouter, TransferRouter
+from src.inventory.warehouse.infra.routes import WarehouseRouter
+from src.purchasing.infra.routes import POItemRouter, PurchaseOrderRouter
+from src.reports.inventory.infra.routes import ReportRouter
+from src.sales.infra.routes import SaleRouter
+from src.suppliers.infra.routes import (
+    SupplierContactRouter,
+    SupplierProductRouter,
+    SupplierRouter,
+)
+
+
+def _build_admin_app() -> FastAPI:
+    app = FastAPI()
+    admin = APIRouter(prefix="/api/admin")
+    admin.include_router(CategoryRouter().router, prefix="/categories")
+    admin.include_router(UnitOfMeasureRouter().router, prefix="/units-of-measure")
+    admin.include_router(ProductRouter().router, prefix="/products")
+    admin.include_router(WarehouseRouter().router, prefix="/warehouses")
+    admin.include_router(LocationRouter().router, prefix="/locations")
+    admin.include_router(StockRouter().router, prefix="/stock")
+    admin.include_router(MovementRouter().router, prefix="/movements")
+    admin.include_router(LotRouter().router, prefix="/lots")
+    admin.include_router(SerialRouter().router, prefix="/serials")
+    admin.include_router(CustomerRouter().router, prefix="/customers")
+    admin.include_router(CustomerContactRouter().router, prefix="/customer-contacts")
+    admin.include_router(SupplierRouter().router, prefix="/suppliers")
+    admin.include_router(SupplierContactRouter().router, prefix="/supplier-contacts")
+    admin.include_router(SupplierProductRouter().router, prefix="/supplier-products")
+    admin.include_router(PurchaseOrderRouter().router, prefix="/purchase-orders")
+    admin.include_router(POItemRouter().router, prefix="/purchase-order-items")
+    admin.include_router(SaleRouter().router, prefix="/sales")
+    admin.include_router(AdjustmentRouter().router, prefix="/adjustments")
+    admin.include_router(AdjustmentItemRouter().router, prefix="/adjustment-items")
+    admin.include_router(TransferRouter().router, prefix="/transfers")
+    admin.include_router(TransferItemRouter().router, prefix="/transfer-items")
+    admin.include_router(AlertRouter().router, prefix="/alerts")
+    admin.include_router(UserAdminRouter().router, prefix="/users")
+    admin.include_router(ReportRouter().router, prefix="/reports/inventory")
+    app.include_router(admin)
+    return app
+
+
+_APP = _build_admin_app()
+
+
+def _tree_contains_call(dep: Dependant, target) -> bool:
+    if dep.call is target:
+        return True
+    return any(_tree_contains_call(sub, target) for sub in dep.dependencies)
+
+
+def _admin_routes() -> list[APIRoute]:
+    return [
+        r
+        for r in _APP.routes
+        if isinstance(r, APIRoute) and r.path.startswith("/api/admin")
+    ]
+
+
+def test_every_admin_route_requires_authenticated_user():
+    unprotected: list[str] = []
+    for route in _admin_routes():
+        if not _tree_contains_call(route.dependant, get_current_user):
+            for method in sorted(route.methods or []):
+                unprotected.append(f"{method} {route.path}")
+    assert not unprotected, (
+        "Admin routes missing require_permission/get_current_user:\n  - "
+        + "\n  - ".join(unprotected)
+    )
+
+
+def test_admin_routes_exist():
+    """Sanity check — the filter is actually finding routes."""
+    assert len(_admin_routes()) > 0

--- a/tests/integration/auth/test_all_pos_routes_require_auth.py
+++ b/tests/integration/auth/test_all_pos_routes_require_auth.py
@@ -1,0 +1,64 @@
+"""Guard test: every /api/pos route must carry a require_permission dependency.
+
+This fails if a new POS router is added without authorization coverage.
+"""
+
+from fastapi import APIRouter, FastAPI
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute
+
+from src.auth.infra.dependencies import get_current_user
+from src.pos.cash.infra.routes import POSCashRouter
+from src.pos.infra.routes import POSCustomerRouter, POSProductRouter
+from src.pos.refund.infra.routes import POSRefundRouter
+from src.pos.reports.infra.routes import POSReportRouter
+from src.pos.sales.infra.routes import POSSaleRouter
+from src.pos.shift.infra.routes import POSShiftRouter
+
+
+def _build_pos_app() -> FastAPI:
+    app = FastAPI()
+    pos = APIRouter(prefix="/api/pos")
+    pos.include_router(POSSaleRouter().router, prefix="/sales")
+    pos.include_router(POSShiftRouter().router, prefix="/shifts")
+    pos.include_router(POSProductRouter().router, prefix="/products")
+    pos.include_router(POSCustomerRouter().router, prefix="/customers")
+    pos.include_router(POSRefundRouter().router, prefix="/refunds")
+    pos.include_router(POSCashRouter().router, prefix="/shifts")
+    pos.include_router(POSReportRouter().router, prefix="/reports")
+    app.include_router(pos)
+    return app
+
+
+_APP = _build_pos_app()
+
+
+def _tree_contains_call(dep: Dependant, target) -> bool:
+    if dep.call is target:
+        return True
+    return any(_tree_contains_call(sub, target) for sub in dep.dependencies)
+
+
+def _pos_routes() -> list[APIRoute]:
+    return [
+        r
+        for r in _APP.routes
+        if isinstance(r, APIRoute) and r.path.startswith("/api/pos")
+    ]
+
+
+def test_every_pos_route_requires_authenticated_user():
+    unprotected: list[str] = []
+    for route in _pos_routes():
+        if not _tree_contains_call(route.dependant, get_current_user):
+            for method in sorted(route.methods or []):
+                unprotected.append(f"{method} {route.path}")
+    assert not unprotected, (
+        "POS routes missing require_permission/get_current_user:\n  - "
+        + "\n  - ".join(unprotected)
+    )
+
+
+def test_pos_routes_exist():
+    """Sanity check — the filter is actually finding routes."""
+    assert len(_pos_routes()) > 0

--- a/tests/integration/auth/test_cashier_role.py
+++ b/tests/integration/auth/test_cashier_role.py
@@ -1,0 +1,94 @@
+import pytest
+
+from src.auth.domain.entities import AuthenticatedUser, Role
+from src.auth.domain.exceptions import PermissionDeniedError
+from src.auth.domain.permissions import Permission, permissions_for
+from src.auth.infra.dependencies import require_permission
+
+
+def _make_user(role: Role) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=1,
+        username="cashier01",
+        role=role,
+        permissions=permissions_for(role),
+    )
+
+
+def test_cashier_passes_pos_operate():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.POS_OPERATE)
+    assert dep(user=cashier).role == Role.CASHIER
+
+
+def test_cashier_passes_sale_write():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.SALE_WRITE)
+    assert dep(user=cashier).role == Role.CASHIER
+
+
+def test_cashier_passes_customer_write():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.CUSTOMER_WRITE)
+    assert dep(user=cashier).role == Role.CASHIER
+
+
+def test_cashier_passes_report_pos_read():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.REPORT_POS_READ)
+    assert dep(user=cashier).role == Role.CASHIER
+
+
+def test_cashier_blocked_on_user_manage():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.USER_MANAGE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=cashier)
+
+
+def test_cashier_blocked_on_purchase_write():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.PURCHASE_WRITE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=cashier)
+
+
+def test_cashier_blocked_on_adjustment_write():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.ADJUSTMENT_WRITE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=cashier)
+
+
+def test_cashier_blocked_on_refund_approve():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.REFUND_APPROVE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=cashier)
+
+
+def test_cashier_blocked_on_sale_cancel():
+    cashier = _make_user(Role.CASHIER)
+    dep = require_permission(Permission.SALE_CANCEL)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=cashier)
+
+
+def test_operator_blocked_on_pos_operate():
+    operator = _make_user(Role.OPERATOR)
+    dep = require_permission(Permission.POS_OPERATE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=operator)
+
+
+def test_manager_blocked_on_pos_operate():
+    manager = _make_user(Role.MANAGER)
+    dep = require_permission(Permission.POS_OPERATE)
+    with pytest.raises(PermissionDeniedError):
+        dep(user=manager)
+
+
+def test_manager_passes_refund_approve():
+    manager = _make_user(Role.MANAGER)
+    dep = require_permission(Permission.REFUND_APPROVE)
+    assert dep(user=manager).role == Role.MANAGER

--- a/tests/unit/auth/test_permissions.py
+++ b/tests/unit/auth/test_permissions.py
@@ -6,42 +6,51 @@ def test_admin_has_all_permissions():
     assert permissions_for(Role.ADMIN) == frozenset(Permission)
 
 
-def test_manager_permissions():
-    expected = frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.PRODUCT_WRITE,
-            Permission.STOCK_READ,
-            Permission.MOVEMENT_WRITE,
-            Permission.SALE_READ,
-            Permission.SALE_WRITE,
-            Permission.SALE_CANCEL,
-        }
-    )
-    assert permissions_for(Role.MANAGER) == expected
+def test_manager_has_everything_but_user_manage_and_pos_operate():
+    perms = permissions_for(Role.MANAGER)
+    assert Permission.USER_MANAGE not in perms
+    assert Permission.POS_OPERATE not in perms
+    assert Permission.SALE_CANCEL in perms
+    assert Permission.PURCHASE_CONFIRM in perms
+    assert Permission.PURCHASE_RECEIVE in perms
+    assert Permission.REFUND_APPROVE in perms
 
 
-def test_operator_permissions():
-    expected = frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.STOCK_READ,
-            Permission.SALE_READ,
-            Permission.SALE_WRITE,
-        }
-    )
-    assert permissions_for(Role.OPERATOR) == expected
+def test_operator_has_back_office_writes_but_not_critical_ops():
+    perms = permissions_for(Role.OPERATOR)
+    assert Permission.PRODUCT_WRITE in perms
+    assert Permission.MOVEMENT_WRITE in perms
+    assert Permission.ADJUSTMENT_WRITE in perms
+    assert Permission.PURCHASE_WRITE in perms
+    assert Permission.SALE_WRITE in perms
+    assert Permission.SALE_CANCEL not in perms
+    assert Permission.PURCHASE_CONFIRM not in perms
+    assert Permission.REFUND_APPROVE not in perms
+    assert Permission.POS_OPERATE not in perms
+    assert Permission.USER_MANAGE not in perms
 
 
-def test_viewer_permissions():
-    expected = frozenset(
-        {
-            Permission.PRODUCT_READ,
-            Permission.STOCK_READ,
-            Permission.SALE_READ,
-        }
-    )
-    assert permissions_for(Role.VIEWER) == expected
+def test_viewer_only_has_reads():
+    perms = permissions_for(Role.VIEWER)
+    for p in perms:
+        assert p.value.endswith(":read"), f"viewer should only have reads, got {p}"
+    assert Permission.PRODUCT_READ in perms
+    assert Permission.SALE_READ in perms
+    assert Permission.REPORT_INVENTORY_READ in perms
+    assert Permission.REPORT_POS_READ in perms
+    assert Permission.PRODUCT_WRITE not in perms
+
+
+def test_cashier_can_operate_pos_but_not_admin():
+    perms = permissions_for(Role.CASHIER)
+    assert Permission.POS_OPERATE in perms
+    assert Permission.SALE_WRITE in perms
+    assert Permission.CUSTOMER_WRITE in perms
+    assert Permission.REPORT_POS_READ in perms
+    assert Permission.USER_MANAGE not in perms
+    assert Permission.PURCHASE_WRITE not in perms
+    assert Permission.MOVEMENT_WRITE not in perms
+    assert Permission.SALE_CANCEL not in perms
 
 
 def test_viewer_cannot_write_products():


### PR DESCRIPTION
## Descripción

  - Add CASHIER role (5) and 22 new permissions (POS_OPERATE, REFUND_APPROVE, *_WRITE for catalog/inventory/partners, PURCHASE_*, REPORT_*) to PERMISSIONS_BY_ROLE.
  - Apply require_permission to every admin and POS router (catalog, inventory, customers, suppliers, purchasing, sales, reports, pos/sales|shift|cash|refund|reports|product|customer).
  - Declare bearerAuth securityScheme in OpenAPI; mark /api/auth/login and /api/auth/refresh as public.
  - Fail-safe JWT_SECRET in staging/production: refuse to start with the dev default or secrets shorter than 32 chars.
  - Add guard tests that introspect FastAPI route trees to ensure every /api/admin and /api/pos route depends on get_current_user.
  - Add cashier role tests and CASHIER cases to permission tests.
  - Document the auth contract in docs/auth-spec.md.

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [x] Nueva funcionalidad (feature)
- [ ] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
