### PR TITLE
docs: document auth flow in Scalar and fix role validator bounds

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -86,6 +86,80 @@ domain model.
 | **Admin** | `/api/admin` | [`/docs/admin`](/docs/admin) | Back-office: catalog, inventory, warehouses, customers, suppliers, purchasing, sales reporting, and analytics. |
 | **POS** | `/api/pos` | [`/docs/pos`](/docs/pos) | Point-of-sale terminal: product lookup, customer search, shift management, full sales lifecycle, refunds, cash drawer, and operational reports. |
 
+Authentication endpoints live under `/api/auth` and are included in **all three docs**, since both Admin and POS surfaces require a Bearer token.
+
+---
+
+## Authentication
+
+All endpoints — except `POST /api/auth/login` and `POST /api/auth/refresh` — require a **JWT Bearer token** (`HS256`) in the `Authorization` header:
+
+```
+Authorization: Bearer <accessToken>
+```
+
+### Flow
+
+1. **Login** — `POST /api/auth/login` with `{ "username": "...", "password": "..." }`. Receive an `accessToken` and a `refreshToken`.
+2. **Authenticated calls** — send `Authorization: Bearer <accessToken>` on every request.
+3. **Refresh** — when the access token expires (the API responds with a `TOKEN_EXPIRED` error), `POST /api/auth/refresh` with `{ "refreshToken": "..." }` to obtain a new pair. The refresh token is also rotated.
+4. **Profile / change password** — `GET /api/auth/me` and `POST /api/auth/change-password` operate on the currently authenticated user.
+
+### Token lifetimes
+
+| Token | Default TTL | Env override |
+|-------|-------------|--------------|
+| Access | 15 minutes | `JWT_ACCESS_TTL_SECONDS` |
+| Refresh | 7 days | `JWT_REFRESH_TTL_SECONDS` |
+
+The signing secret is `JWT_SECRET` and the issuer claim is `JWT_ISSUER` (default `faclab-core`).
+
+### Roles & permissions
+
+Authorization is permission-based. Each user holds a single role, and each role expands to a set of granular permissions (e.g. `product:read`, `sale:cancel`, `pos:operate`, `user:manage`). Endpoints declare the permissions they require; missing permissions return a `PERMISSION_DENIED` error.
+
+| Role | Intended for | Highlights |
+|------|--------------|------------|
+| **ADMIN** | System owner / IT | Full access, including user management. |
+| **MANAGER** | Store / branch manager | Everything except user management and POS. Can confirm purchases, cancel sales, approve refunds. |
+| **OPERATOR** | Back-office / warehouse staff | Inventory writes (movements, lots, serials, adjustments, transfers), product/customer/supplier writes, sale & purchase create — no critical approvals, no POS, no user management. |
+| **VIEWER** | Auditors / accountants | Read-only across the catalog, inventory, sales, purchases, customers, suppliers, alerts and reports. |
+| **CASHIER** | POS terminal operator | POS operations, sale create/read, customer create/read, product/stock read, POS reports. No inventory writes, no approvals, no admin. |
+
+### Authorization errors
+
+| HTTP | Error code | Meaning |
+|------|------------|---------|
+| 400 | `INVALID_CREDENTIALS` | Wrong username/password, or user is inactive. |
+| 400 | `TOKEN_EXPIRED` | Access (or refresh) token expired — call `/api/auth/refresh` or log in again. |
+| 400 | `INVALID_TOKEN` | Token is malformed, signed with a wrong secret, or refers to a user that no longer exists/is active. |
+| 400 | `PERMISSION_DENIED` | Authenticated, but missing one or more permissions required by the endpoint. |
+
+### Trying it from this UI
+
+Click the **lock icon** at the top of any endpoint, choose **`bearerAuth`**, and paste the `accessToken` value (without the `Bearer ` prefix). Scalar will inject the `Authorization` header on every "Try it" request.
+
+### curl example
+
+```bash
+# 1. Login
+TOKENS=$(curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"change-me"}')
+
+ACCESS=$(echo "$TOKENS" | jq -r '.data.accessToken')
+REFRESH=$(echo "$TOKENS" | jq -r '.data.refreshToken')
+
+# 2. Call a protected endpoint
+curl -s http://localhost:3000/api/auth/me \
+  -H "Authorization: Bearer $ACCESS"
+
+# 3. Refresh when the access token expires
+curl -s -X POST http://localhost:3000/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d "{\"refreshToken\":\"$REFRESH\"}"
+```
+
 ---
 
 ## Response format
@@ -159,6 +233,23 @@ All errors follow a consistent structure with one or more error entries:
 """
 
     API_OPENAPI_TAGS: list[dict] = [
+        # Administration — Auth & Users
+        {
+            "name": "Auth",
+            "description": (
+                "Authentication endpoints — login, refresh access tokens, get the "
+                "current authenticated user, and change password. "
+                "**`POST /api/auth/login` and `POST /api/auth/refresh` are public**; "
+                "all other endpoints require a Bearer token."
+            ),
+        },
+        {
+            "name": "Users",
+            "description": (
+                "Administer system users: create, list, view, update role, "
+                "activate and deactivate. Requires the `user:manage` permission."
+            ),
+        },
         # Admin — Catalog
         {
             "name": "Categories",
@@ -327,6 +418,10 @@ All errors follow a consistent structure with one or more error entries:
     ]
 
     API_TAG_GROUPS: list[dict] = [
+        {
+            "name": "Administration",
+            "tags": ["Auth", "Users"],
+        },
         {
             "name": "Catalog",
             "tags": [

--- a/main.py
+++ b/main.py
@@ -144,14 +144,14 @@ def _scalar_response(title: str, schema_url: str) -> HTMLResponse:
     )
 
 
-def _filtered_schema(path_prefix: str) -> dict:
-    """Return a deepcopy of the full schema containing only operations whose paths start with *path_prefix*."""
+def _filtered_schema(path_prefixes: tuple[str, ...]) -> dict:
+    """Return a deepcopy of the full schema containing only operations whose paths start with one of *path_prefixes*."""
     schema = copy.deepcopy(app.openapi())
     used_tags: set[str] = set()
     filtered_paths: dict = {}
 
     for path, path_item in schema.get("paths", {}).items():
-        if not path.startswith(path_prefix):
+        if not any(path.startswith(p) for p in path_prefixes):
             continue
         filtered_paths[path] = path_item
         for _method, operation in path_item.items():
@@ -330,11 +330,11 @@ if _docs.enabled:
 
     @app.get("/openapi/admin.json", include_in_schema=False)
     async def admin_openapi_schema():
-        return JSONResponse(_filtered_schema("/api/admin"))
+        return JSONResponse(_filtered_schema(("/api/admin", "/api/auth")))
 
     @app.get("/openapi/pos.json", include_in_schema=False)
     async def pos_openapi_schema():
-        return JSONResponse(_filtered_schema("/api/pos"))
+        return JSONResponse(_filtered_schema(("/api/pos", "/api/auth")))
 
 
 # ---------------------------------------------------------------------------

--- a/src/auth/infra/validators.py
+++ b/src/auth/infra/validators.py
@@ -40,9 +40,9 @@ class AuthenticatedUserResponse(BaseModel):
     id: int = Field(ge=1)
     username: str
     role: int = Field(
-        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)"
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER, 5=CASHIER)"
     )
-    permissions: list[str] = Field(default_factory=list)
+    permissions: list[str] = []
 
 
 class CreateUserRequest(BaseModel):
@@ -54,8 +54,8 @@ class CreateUserRequest(BaseModel):
     role: int = Field(
         4,
         ge=1,
-        le=4,
-        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)",
+        le=5,
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER, 5=CASHIER)",
     )
 
 
@@ -65,8 +65,8 @@ class UpdateUserRoleRequest(BaseModel):
     role: int = Field(
         ...,
         ge=1,
-        le=4,
-        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)",
+        le=5,
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER, 5=CASHIER)",
     )
 
 
@@ -77,7 +77,7 @@ class UserResponse(BaseModel):
     username: str
     email: str
     role: int = Field(
-        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER)"
+        description="Role code (1=ADMIN, 2=MANAGER, 3=OPERATOR, 4=VIEWER, 5=CASHIER)"
     )
     is_active: bool
     last_login_at: datetime | None = None
@@ -86,4 +86,4 @@ class UserResponse(BaseModel):
 
 class UserQueryParams(QueryParams):
     is_active: bool | None = Field(None, description="Filter by active status")
-    role: int | None = Field(None, ge=1, le=4, description="Filter by role")
+    role: int | None = Field(None, ge=1, le=5, description="Filter by role")


### PR DESCRIPTION
## Descripción

- Add Auth and Users tag descriptions and a new Administration tag group so both appear in the Scalar sidebar.
  - Extend API_DESCRIPTION with a full authentication section: JWT flow, token lifetimes, roles table, error codes, Scalar lock-icon usage and a curl example.
  - Include /api/auth/* in /docs/admin and /docs/pos by making _filtered_schema accept a tuple of path prefixes.
  - Fix CreateUserRequest, UpdateUserRoleRequest and UserQueryParams role bounds (le=4 → le=5) so the CASHIER role can be assigned and filtered. Align role descriptions to include 5=CASHIER.
  - Replace  with a literal  default to silence the Pydantic non-serializable-default JSON-schema warning.

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [x] Nueva funcionalidad (feature)
- [ ] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
