### PR TITLE
fix: add tax_rate to UpdateProductCommand and normalize empty barcode to null

### DIFF
--- a/src/catalog/product/app/commands/update_product.py
+++ b/src/catalog/product/app/commands/update_product.py
@@ -22,6 +22,7 @@ class UpdateProductCommand(Command):
     unit_of_measure_id: int | None = None
     purchase_price: Decimal | None = None
     sale_price: Decimal | None = None
+    tax_rate: Decimal = Decimal("15.00")
     is_active: bool = True
     is_service: bool = False
     min_stock: int = 0
@@ -51,6 +52,7 @@ class UpdateProductCommandHandler(CommandHandler[UpdateProductCommand, dict]):
             unit_of_measure_id=command.unit_of_measure_id,
             purchase_price=command.purchase_price,
             sale_price=command.sale_price,
+            tax_rate=command.tax_rate,
             is_active=command.is_active,
             is_service=command.is_service,
             min_stock=command.min_stock,
@@ -70,6 +72,7 @@ class UpdateProductCommandHandler(CommandHandler[UpdateProductCommand, dict]):
             "unit_of_measure_id",
             "purchase_price",
             "sale_price",
+            "tax_rate",
             "is_active",
             "is_service",
             "min_stock",

--- a/src/catalog/product/infra/validators.py
+++ b/src/catalog/product/infra/validators.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 
 from src.shared.infra.validators import DecimalNumber, QueryParams
@@ -18,6 +18,14 @@ class ProductRequest(BaseModel):
     name: str = Field(description="Product name")
     sku: str = Field(description="Stock Keeping Unit — unique product code")
     description: str | None = Field(None, description="Product description")
+
+    @field_validator("barcode", mode="before")
+    @classmethod
+    def empty_str_to_none(cls, v: str | None) -> str | None:
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+    
     barcode: str | None = Field(None, description="Barcode (EAN/UPC)")
     category_id: int | None = Field(None, ge=1, description="Category ID")
     unit_of_measure_id: int | None = Field(None, ge=1, description="Unit of measure ID")


### PR DESCRIPTION
## Descripción

  - Add missing tax_rate field to UpdateProductCommand (caused TypeError on PUT /products/{id})
  - Pass tax_rate when constructing Product in UpdateProductCommandHandler
  - Include tax_rate in change-tracking for ProductUpdated event
  - Add field_validator on barcode to convert empty string to null (prevented duplicate key violation on products_barcode_key unique constraint)

## Tipo de cambio

<!-- Marca con una 'x' el tipo de cambio que aplica -->

- [ ] Nueva funcionalidad (feature)
- [x] Corrección de bug (fix)
- [ ] Refactorización (refactor)
- [ ] Documentación (docs)
- [ ] Pruebas (test)
- [ ] Otros

## Checklist

- [ ] El código sigue las convenciones del proyecto
- [ ] Se han ejecutado las pruebas y pasan correctamente
- [ ] Se han actualizado las migraciones de base de datos (si aplica)
